### PR TITLE
fix null rules

### DIFF
--- a/src/main/java/org/hyperledger/fabric/sdk/transaction/InstallProposalBuilder.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/transaction/InstallProposalBuilder.java
@@ -141,7 +141,7 @@ public class InstallProposalBuilder extends LSCCProposalBuilder {
                 // chaincodeSource may be a File or InputStream
 
                 //   Verify that chaincodePath is null
-                if (null != chaincodePath) {
+                if (!Utils.isNullOrEmpty(chaincodePath)) {
                     throw new IllegalArgumentException("chaincodePath must be null for Java chaincode");
                 }
 


### PR DESCRIPTION
`chaincodePath` cannot be null in the current implementation (getter will prevent returning null value). Therefore the sanity check for null will always fail, because at best chaincodePath will be empty string. It happens only for Java chaincode that is not officially supported. But this change would help anyone that dares to try.