### PR TITLE
check empty value to avoid NPE when trying to set the path to null

### DIFF
--- a/src/main/java/org/hyperledger/fabric/sdk/transaction/InstallProposalBuilder.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/transaction/InstallProposalBuilder.java
@@ -141,7 +141,7 @@ public class InstallProposalBuilder extends LSCCProposalBuilder {
                 // chaincodeSource may be a File or InputStream
 
                 //   Verify that chaincodePath is null
-                if (null != chaincodePath) {
+                if (null != chaincodePath && chaincodePath.isEmpty()) {
                     throw new IllegalArgumentException("chaincodePath must be null for Java chaincode");
                 }
 


### PR DESCRIPTION
When trying to set the chaincodePath to null, a NPE is fired because of validation. Since the value is not initialized to null, there is no way to bypass the fixed check. Accepting empty string, the check will pass if no chaincodePath has been set at all.