### PR TITLE
bugfix: possible NPE in SDKUtils.calculateBlockHash()

### DIFF
--- a/src/main/java/org/hyperledger/fabric/sdk/SDKUtils.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/SDKUtils.java
@@ -62,7 +62,7 @@ public class SDKUtils {
         }
 
         CryptoSuite cryptoSuite = client.getCryptoSuite();
-        if (null == client) {
+        if (null == cryptoSuite) {
             throw new InvalidArgumentException("Client crypto suite has not  been set.");
         }
 


### PR DESCRIPTION
- check "cryptoSuite" instead of "client" for null reference