### PR TITLE
FABJ-497 update version of bouncycastle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.4.7
+Mon 11 Nov 2019 15:04:20 GMT
+
+* [c7469f8](https://github.com/hyperledger/fabric-sdk-java/commit/c7469f8) FABJ-497 update version of bouncycastle
+
 ## v1.4.6
 Fri  8 Nov 2019 14:26:57 GMT
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.hyperledger.fabric-sdk-java</groupId>
     <artifactId>fabric-sdk-java</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.6</version>
+    <version>1.4.7</version>
     <name>fabric-java-sdk</name>
     <description>Java SDK for Hyperledger fabric project</description>
     <url>https://www.hyperledger.org/community/projects</url>
@@ -30,7 +30,7 @@
     <properties>
         <grpc.version>1.23.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
         <protobuf.version>3.10.0</protobuf.version>
-        <bouncycastle.version>1.63</bouncycastle.version>
+        <bouncycastle.version>1.62</bouncycastle.version>
         <httpclient.version>4.5.10</httpclient.version>
         <javadoc.version>3.1.1</javadoc.version>
         <skipITs>true</skipITs>


### PR DESCRIPTION
To avoid security alert in v1.63 of bouncycastle
Prepare to release v1.4.7

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>