### PR TITLE
FABJ-509: Allow transactions to be submitted without ChaincodeID

### DIFF
--- a/src/main/java/org/hyperledger/fabric/sdk/Channel.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/Channel.java
@@ -4421,9 +4421,6 @@ public class Channel implements Serializable {
         if (isNullOrEmpty(transactionProposalRequest.getFcn())) {
             throw new InvalidArgumentException("The proposalRequest's fcn is null or empty.");
         }
-        if (transactionProposalRequest.getChaincodeID() == null) {
-            throw new InvalidArgumentException("The proposalRequest's chaincode ID is null");
-        }
         if (null == serviceDiscovery) {
             throw new ServiceDiscoveryException("The channel is not configured with any peers with the 'discover' role");
         }
@@ -4832,10 +4829,6 @@ public class Channel implements Serializable {
         if (isNullOrEmpty(proposalRequest.getFcn())) {
             throw new InvalidArgumentException("The proposalRequest's fcn is null or empty.");
         }
-
-//        if (proposalRequest.getChaincodeID() == null) {
-//            throw new InvalidArgumentException("The proposalRequest's chaincode ID is null");
-//        }
 
         try {
             TransactionContext transactionContext = getTransactionContext(proposalRequest.getUserContext());

--- a/src/test/java/org/hyperledger/fabric/sdkintegration/ServiceDiscoveryIT.java
+++ b/src/test/java/org/hyperledger/fabric/sdkintegration/ServiceDiscoveryIT.java
@@ -192,7 +192,7 @@ public class ServiceDiscoveryIT {
         assertFalse(transactionPropResp.isEmpty());
 
         transactionProposalRequest = client.newTransactionProposalRequest();
-        transactionProposalRequest.setChaincodeID(chaincodeID);
+        transactionProposalRequest.setChaincodeName(CHAIN_CODE_NAME);
         transactionProposalRequest.setChaincodeLanguage(CHAIN_CODE_LANG);
         transactionProposalRequest.setFcn("move");
         transactionProposalRequest.setProposalWaitTime(testConfig.getProposalWaitTime());


### PR DESCRIPTION
Remove the check for the presence of ChaincodeID when invoking
transactions using service discovery. ChaincodeName can now be
specified as an alternative to ChaincodeID and ChaincodeID is
deprecated, so this check is redundant.