### PR TITLE
Use SafeConstructor with YAML parser

### DIFF
--- a/src/main/java/org/hyperledger/fabric/sdk/ChaincodeCollectionConfiguration.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/ChaincodeCollectionConfiguration.java
@@ -44,6 +44,7 @@ import org.hyperledger.fabric.protos.common.Policies.SignaturePolicy;
 import org.hyperledger.fabric.sdk.exception.ChaincodeCollectionConfigurationException;
 import org.hyperledger.fabric.sdk.exception.InvalidArgumentException;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import static java.lang.String.format;
 
@@ -112,7 +113,7 @@ public class ChaincodeCollectionConfiguration {
             throw new InvalidArgumentException("ConfigStream must be specified");
         }
 
-        Yaml yaml = new Yaml();
+        Yaml yaml = new Yaml(new SafeConstructor());
 
         @SuppressWarnings ("unchecked")
         List<Object> map = yaml.load(configStream);

--- a/src/main/java/org/hyperledger/fabric/sdk/ChaincodeEndorsementPolicy.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/ChaincodeEndorsementPolicy.java
@@ -33,6 +33,7 @@ import org.hyperledger.fabric.protos.common.Policies;
 import org.hyperledger.fabric.protos.common.Policies.SignaturePolicy;
 import org.hyperledger.fabric.sdk.exception.ChaincodeEndorsementPolicyParseException;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import static java.lang.String.format;
 
@@ -232,7 +233,7 @@ public class ChaincodeEndorsementPolicy {
      */
 
     public void fromYamlFile(File yamlPolicyFile) throws IOException, ChaincodeEndorsementPolicyParseException {
-        final Yaml yaml = new Yaml();
+        final Yaml yaml = new Yaml(new SafeConstructor());
         final Map<?, ?> load = (Map<?, ?>) yaml.load(new FileInputStream(yamlPolicyFile));
 
         Map<?, ?> mp = (Map<?, ?>) load.get("policy");

--- a/src/main/java/org/hyperledger/fabric/sdk/NetworkConfig.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/NetworkConfig.java
@@ -57,6 +57,7 @@ import org.hyperledger.fabric.sdk.exception.NetworkConfigurationException;
 import org.hyperledger.fabric.sdk.identity.X509Enrollment;
 import org.hyperledger.fabric.sdk.security.CryptoSuite;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import static java.lang.String.format;
 import static org.hyperledger.fabric.sdk.helper.Utils.isNullOrEmpty;
@@ -334,7 +335,7 @@ public class NetworkConfig {
             throw new InvalidArgumentException("configStream must be specified");
         }
 
-        Yaml yaml = new Yaml();
+        Yaml yaml = new Yaml(new SafeConstructor());
 
         @SuppressWarnings ("unchecked")
         Map<String, Object> map = yaml.load(configStream);


### PR DESCRIPTION
Construct the YAML parser with the SafeConstructor to
limit objects to standard Java objects

Signed-off-by: Gari Singh <gari.r.singh@gmail.com>