### PR TITLE
Use SafeConstructor with YAML parser

### DIFF
--- a/src/main/java/org/hyperledger/fabric/sdk/ChaincodeCollectionConfiguration.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/ChaincodeCollectionConfiguration.java
@@ -43,6 +43,7 @@ import org.hyperledger.fabric.protos.peer.Collection;
 import org.hyperledger.fabric.sdk.exception.ChaincodeCollectionConfigurationException;
 import org.hyperledger.fabric.sdk.exception.InvalidArgumentException;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import static java.lang.String.format;
 
@@ -116,7 +117,7 @@ public class ChaincodeCollectionConfiguration {
             throw new InvalidArgumentException("ConfigStream must be specified");
         }
 
-        Yaml yaml = new Yaml();
+        Yaml yaml = new Yaml(new SafeConstructor());
 
         List<Object> map = yaml.load(configStream);
 

--- a/src/main/java/org/hyperledger/fabric/sdk/ChaincodeEndorsementPolicy.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/ChaincodeEndorsementPolicy.java
@@ -34,6 +34,7 @@ import org.hyperledger.fabric.protos.common.Policies;
 import org.hyperledger.fabric.protos.common.Policies.SignaturePolicy;
 import org.hyperledger.fabric.sdk.exception.ChaincodeEndorsementPolicyParseException;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import static java.lang.String.format;
 
@@ -237,7 +238,7 @@ public class ChaincodeEndorsementPolicy {
      */
 
     public void fromYamlFile(File yamlPolicyFile) throws IOException, ChaincodeEndorsementPolicyParseException {
-        final Yaml yaml = new Yaml();
+        final Yaml yaml = new Yaml(new SafeConstructor());
         final Map<?, ?> load = (Map<?, ?>) yaml.load(new FileInputStream(yamlPolicyFile));
 
         Map<?, ?> mp = (Map<?, ?>) load.get("policy");
@@ -258,7 +259,7 @@ public class ChaincodeEndorsementPolicy {
     }
 
     public static ChaincodeEndorsementPolicy fromYamlFile(Path yamlPolicyFile) throws IOException, ChaincodeEndorsementPolicyParseException {
-        final Yaml yaml = new Yaml();
+        final Yaml yaml = new Yaml(new SafeConstructor());
         final Map<?, ?> load = (Map<?, ?>) yaml.load(new FileInputStream(yamlPolicyFile.toFile()));
 
         Map<?, ?> mp = (Map<?, ?>) load.get("policy");

--- a/src/main/java/org/hyperledger/fabric/sdk/LifecycleChaincodeEndorsementPolicy.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/LifecycleChaincodeEndorsementPolicy.java
@@ -29,6 +29,7 @@ import org.hyperledger.fabric.protos.common.Policies.SignaturePolicy;
 import org.hyperledger.fabric.protos.peer.Policy;
 import org.hyperledger.fabric.sdk.exception.ChaincodeEndorsementPolicyParseException;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import static java.lang.String.format;
 
@@ -224,7 +225,7 @@ public class LifecycleChaincodeEndorsementPolicy {
 //    }
 
     public static LifecycleChaincodeEndorsementPolicy fromSignaturePolicyYamlFile(Path yamlPolicyFile) throws IOException, ChaincodeEndorsementPolicyParseException {
-        final Yaml yaml = new Yaml();
+        final Yaml yaml = new Yaml(new SafeConstructor());
         final Map<?, ?> load = (Map<?, ?>) yaml.load(new FileInputStream(yamlPolicyFile.toFile()));
 
         Map<?, ?> mp = (Map<?, ?>) load.get("policy");

--- a/src/main/java/org/hyperledger/fabric/sdk/NetworkConfig.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/NetworkConfig.java
@@ -58,6 +58,7 @@ import org.hyperledger.fabric.sdk.helper.Utils;
 import org.hyperledger.fabric.sdk.identity.X509Enrollment;
 import org.hyperledger.fabric.sdk.security.CryptoSuite;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import static java.lang.String.format;
 import static org.hyperledger.fabric.sdk.helper.Utils.isNullOrEmpty;
@@ -296,7 +297,7 @@ public class NetworkConfig {
             throw new InvalidArgumentException("configStream must be specified");
         }
 
-        Yaml yaml = new Yaml();
+        Yaml yaml = new Yaml(new SafeConstructor());
 
         Map<String, Object> map = yaml.load(configStream);
 


### PR DESCRIPTION
Construct the YAML parser with the SafeConstructor to
limit objects to standard Java objects

Signed-off-by: Gari Singh <gari.r.singh@gmail.com>