### PR TITLE
[FABJ-521] Allow arrays of PEM content in connection profile

### DIFF
--- a/src/test/fixture/sdkintegration/network_configs/network-config.json
+++ b/src/test/fixture/sdkintegration/network_configs/network-config.json
@@ -65,6 +65,9 @@
       "mspid": "Org2MSP",
       "peers": [
         "peer0.org2.example.com"
+      ],
+      "certificateAuthorities": [
+        "ca-org2"
       ]
     }
   },
@@ -118,7 +121,27 @@
         "verify": true
       },
       "tlsCACerts": {
-        "path": "peerOrganizations/org1.example.com/ca/org1.example.com-cert.pem"
+        "path": "peerOrganizations/org1.example.com/ca/org1.example.com-cert.pem",
+        "pem": "-----BEGIN CERTIFICATE----- <etc>"
+      },
+      "registrar": [
+        {
+          "enrollId": "admin",
+          "enrollSecret": "adminpw"
+        }
+      ],
+      "caName": "caNameHere"
+    },
+    "ca-org2": {
+      "url": "https://localhost:8054",
+      "httpOptions": {
+        "verify": true
+      },
+      "tlsCACerts": {
+        "pem": [
+          "-----BEGIN CERTIFICATE----- <1>",
+          "-----BEGIN CERTIFICATE----- <2>"
+        ]
       },
       "registrar": [
         {

--- a/src/test/java/org/hyperledger/fabric/sdk/NetworkConfigTest.java
+++ b/src/test/java/org/hyperledger/fabric/sdk/NetworkConfigTest.java
@@ -16,14 +16,15 @@ package org.hyperledger.fabric.sdk;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
@@ -32,7 +33,6 @@ import javax.json.JsonObjectBuilder;
 import javax.json.JsonValue;
 
 import io.grpc.ManagedChannelBuilder;
-import org.hyperledger.fabric.sdk.exception.InvalidArgumentException;
 import org.hyperledger.fabric.sdk.exception.NetworkConfigurationException;
 import org.hyperledger.fabric.sdk.security.CryptoSuite;
 import org.hyperledger.fabric.sdk.testutils.TestUtils;
@@ -45,11 +45,14 @@ import org.junit.rules.ExpectedException;
 import static java.lang.String.format;
 import static org.hyperledger.fabric.sdk.testutils.TestUtils.getField;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class NetworkConfigTest {
+    private static final Path NETWORK_CONFIG_DIR = Paths.get("src", "test", "fixture", "sdkintegration", "network_configs");
+    private static final Path NETWORK_CONFIG_JSON = NETWORK_CONFIG_DIR.resolve("network-config.json");
+    private static final Path NETWORK_CONFIG_YAML = NETWORK_CONFIG_DIR.resolve("network-config.yaml");
 
     private static final String CHANNEL_NAME = "myChannel";
     private static final String CLIENT_ORG_NAME = "Org1";
@@ -58,34 +61,35 @@ public class NetworkConfigTest {
     private static final String USER_MSP_ID = "MockMSPID";
 
     @Rule
+    @SuppressWarnings("deprecation")
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testLoadFromConfigNullStream() throws Exception {
 
         // Should not be able to instantiate a new instance of "Client" without a valid path to the configuration');
-        thrown.expect(InvalidArgumentException.class);
+        thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("configStream must be specified");
 
-        NetworkConfig.fromJsonStream((InputStream) null);
+        NetworkConfig.fromJsonStream(null);
     }
 
     @Test
     public void testLoadFromConfigNullYamlFile() throws Exception {
         // Should not be able to instantiate a new instance of "Client" without a valid path to the configuration');
-        thrown.expect(InvalidArgumentException.class);
+        thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("configFile must be specified");
 
-        NetworkConfig.fromYamlFile((File) null);
+        NetworkConfig.fromYamlFile(null);
     }
 
     @Test
     public void testLoadFromConfigNullJsonFile() throws Exception {
         // Should not be able to instantiate a new instance of "Client" without a valid path to the configuration');
-        thrown.expect(InvalidArgumentException.class);
+        thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("configFile must be specified");
 
-        NetworkConfig.fromJsonFile((File) null);
+        NetworkConfig.fromJsonFile(null);
     }
 
     @Test
@@ -115,7 +119,7 @@ public class NetworkConfigTest {
     @Test
     public void testLoadFromConfigFileYamlBasic() throws Exception {
 
-        File f = new File("src/test/fixture/sdkintegration/network_configs/network-config.yaml");
+        File f = NETWORK_CONFIG_YAML.toFile();
         NetworkConfig config = NetworkConfig.fromYamlFile(f);
         assertNotNull(config);
         Set<String> channelNames = config.getChannelNames();
@@ -125,7 +129,7 @@ public class NetworkConfigTest {
     @Test
     public void testLoadFromConfigFileJsonBasic() throws Exception {
 
-        File f = new File("src/test/fixture/sdkintegration/network_configs/network-config.json");
+        File f = NETWORK_CONFIG_JSON.toFile();
         NetworkConfig config = NetworkConfig.fromJsonFile(f);
         assertNotNull(config);
     }
@@ -134,7 +138,7 @@ public class NetworkConfigTest {
     public void testLoadFromConfigFileYaml() throws Exception {
 
         // Should be able to instantiate a new instance of "Client" with a valid path to the YAML configuration
-        File f = new File("src/test/fixture/sdkintegration/network_configs/network-config.yaml");
+        File f = NETWORK_CONFIG_YAML.toFile();
         NetworkConfig config = NetworkConfig.fromYamlFile(f);
         //HFClient client = HFClient.loadFromConfig(f);
         assertNotNull(config);
@@ -151,7 +155,7 @@ public class NetworkConfigTest {
     public void testLoadFromConfigFileJson() throws Exception {
 
         // Should be able to instantiate a new instance of "Client" with a valid path to the JSON configuration
-        File f = new File("src/test/fixture/sdkintegration/network_configs/network-config.json");
+        File f = NETWORK_CONFIG_JSON.toFile();
         NetworkConfig config = NetworkConfig.fromJsonFile(f);
         assertNotNull(config);
 
@@ -175,7 +179,7 @@ public class NetworkConfigTest {
     public void testLoadFromConfigNoOrganization() throws Exception {
 
         // Should not be able to instantiate a new instance of "Channel" without specifying a valid client organization
-        thrown.expect(InvalidArgumentException.class);
+        thrown.expect(NetworkConfigurationException.class);
         thrown.expectMessage("client organization must be specified");
 
         JsonObject jsonConfig = getJsonConfig1(0, 1, 0);
@@ -217,7 +221,7 @@ public class NetworkConfigTest {
         thrown.expectMessage("Channel MissingChannel not found in configuration file. Found channel names: foo");
 
         // Should be able to instantiate a new instance of "Client" with a valid path to the YAML configuration
-        File f = new File("src/test/fixture/sdkintegration/network_configs/network-config.yaml");
+        File f = NETWORK_CONFIG_YAML.toFile();
         NetworkConfig config = NetworkConfig.fromYamlFile(f);
         //HFClient client = HFClient.loadFromConfig(f);
         assertNotNull(config);
@@ -279,7 +283,7 @@ public class NetworkConfigTest {
     public void testLoadFromConfigFileYamlNOOverrides() throws Exception {
 
         // Should be able to instantiate a new instance of "Client" with a valid path to the YAML configuration
-        File f = new File("src/test/fixture/sdkintegration/network_configs/network-config.yaml");
+        File f = NETWORK_CONFIG_YAML.toFile();
         NetworkConfig config = NetworkConfig.fromYamlFile(f);
 
         //HFClient client = HFClient.loadFromConfig(f);
@@ -292,7 +296,7 @@ public class NetworkConfigTest {
         Channel channel = client.loadChannelFromConfig("foo", config);
         assertNotNull(channel);
 
-        assertTrue(!channel.getPeers().isEmpty());
+        assertFalse(channel.getPeers().isEmpty());
 
         for (Peer peer : channel.getPeers()) {
 
@@ -318,7 +322,7 @@ public class NetworkConfigTest {
     public void testLoadFromConfigFileYamlNOOverridesButSet() throws Exception {
 
         // Should be able to instantiate a new instance of "Client" with a valid path to the YAML configuration
-        File f = new File("src/test/fixture/sdkintegration/network_configs/network-config.yaml");
+        File f = NETWORK_CONFIG_YAML.toFile();
         NetworkConfig config = NetworkConfig.fromYamlFile(f);
 
         //HFClient client = HFClient.loadFromConfig(f);
@@ -331,7 +335,7 @@ public class NetworkConfigTest {
         Channel channel = client.loadChannelFromConfig("foo", config);
         assertNotNull(channel);
 
-        assertTrue(!channel.getOrderers().isEmpty());
+        assertFalse(channel.getOrderers().isEmpty());
 
         for (Orderer orderer : channel.getOrderers()) {
 
@@ -350,7 +354,7 @@ public class NetworkConfigTest {
     public void testLoadFromConfigFileYamlOverrides() throws Exception {
 
         // Should be able to instantiate a new instance of "Client" with a valid path to the YAML configuration
-        File f = new File("src/test/fixture/sdkintegration/network_configs/network-config.yaml");
+        File f = NETWORK_CONFIG_YAML.toFile();
         NetworkConfig config = NetworkConfig.fromYamlFile(f);
 
         for (String peerName : config.getPeerNames()) {
@@ -381,7 +385,7 @@ public class NetworkConfigTest {
         Channel channel = client.loadChannelFromConfig("foo", config);
         assertNotNull(channel);
 
-        assertTrue(!channel.getPeers().isEmpty());
+        assertFalse(channel.getPeers().isEmpty());
 
         for (Peer peer : channel.getPeers()) {
 
@@ -421,7 +425,7 @@ public class NetworkConfigTest {
     public void testPeerOrdererOverrideHandlers() throws Exception {
 
         // Should be able to instantiate a new instance of "Client" with a valid path to the YAML configuration
-        File f = new File("src/test/fixture/sdkintegration/network_configs/network-config.yaml");
+        File f = NETWORK_CONFIG_YAML.toFile();
         NetworkConfig config = NetworkConfig.fromYamlFile(f);
         //HFClient client = HFClient.loadFromConfig(f);
         assertNotNull(config);
@@ -476,6 +480,34 @@ public class NetworkConfigTest {
             assertEquals(expectmaxMessageSizeOrderer, orderer.getProperties().get("grpc.NettyChannelBuilderOption.maxInboundMessageSize"));
         }
 
+    }
+
+    @Test
+    public void testTlsCACertsPemString() throws Exception {
+        File f = NETWORK_CONFIG_JSON.toFile();
+        NetworkConfig config = NetworkConfig.fromJsonFile(f);
+
+        NetworkConfig.OrgInfo orgInfo = config.getOrganizationInfo("Org1");
+        NetworkConfig.CAInfo caInfo = orgInfo.getCertificateAuthorities().get(0);
+        Object pemBytes = caInfo.getProperties().get("pemBytes");
+
+        assertTrue("Expected byte[], got " + pemBytes.getClass().getTypeName(), pemBytes instanceof byte[]);
+        assertTrue("No PEM content", ((byte[]) pemBytes).length > 0);
+    }
+
+    @Test
+    public void testTlsCACertsPemArray() throws Exception {
+        File f = NETWORK_CONFIG_JSON.toFile();
+        NetworkConfig config = NetworkConfig.fromJsonFile(f);
+
+        NetworkConfig.OrgInfo orgInfo = config.getOrganizationInfo("Org2");
+        NetworkConfig.CAInfo caInfo = orgInfo.getCertificateAuthorities().get(0);
+        Object pemBytes = caInfo.getProperties().get("pemBytes");
+
+        assertTrue("Expected byte[], got " + pemBytes.getClass().getTypeName(), pemBytes instanceof byte[]);
+        String pem = new String((byte[]) pemBytes);
+        assertTrue("Missing certificate 1: " + pem, pem.contains("<1>"));
+        assertTrue("Missing certificate 2:" + pem, pem.contains("<2>"));
     }
 
     // TODO: ca-org1 not defined
@@ -610,12 +642,11 @@ public class NetworkConfigTest {
             // Add some peers to the config
             JsonObjectBuilder builder = Json.createObjectBuilder();
 
-            for (int i = 1; i <= nPeers; i++) {
-                String peerName = "peer0.org" + i + ".example.com";
+            for (int orgNo = 1; orgNo <= nPeers; orgNo++) {
+                String peerName = "peer0.org" + orgNo + ".example.com";
 
-                int port1 = (6 + i) * 1000 + 51;         // 7051, 8051, etc
+                int port1 = (6 + orgNo) * 1000 + 51;         // 7051, 8051, etc
 
-                int orgNo = i;
                 int peerNo = 0;
 
                 JsonObject peer = createJsonPeer(

--- a/src/test/java/org/hyperledger/fabric/sdkintegration/NetworkConfigIT.java
+++ b/src/test/java/org/hyperledger/fabric/sdkintegration/NetworkConfigIT.java
@@ -64,6 +64,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hyperledger.fabric.sdk.testutils.TestUtils.getMockUser;
 import static org.hyperledger.fabric.sdk.testutils.TestUtils.resetConfig;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -103,7 +104,7 @@ public class NetworkConfigIT {
 
     private static NetworkConfig networkConfig;
 
-    private static Map<String, User> orgRegisteredUsers = new HashMap<>();
+    private static final Map<String, User> orgRegisteredUsers = new HashMap<>();
 
     @BeforeClass
     public static void doMainSetup() throws Exception {
@@ -116,29 +117,19 @@ public class NetworkConfigIT {
         networkConfig = NetworkConfig.fromYamlFile(testConfig.getTestNetworkConfigFileYAML());
 
         networkConfig.getOrdererNames().forEach(ordererName -> {
-            try {
-                Properties ordererProperties = networkConfig.getOrdererProperties(ordererName);
-                Properties testProp = testConfig.getEndPointProperties("orderer", ordererName);
-                ordererProperties.setProperty("clientCertFile", testProp.getProperty("clientCertFile"));
-                ordererProperties.setProperty("clientKeyFile", testProp.getProperty("clientKeyFile"));
-                networkConfig.setOrdererProperties(ordererName, ordererProperties);
-
-            } catch (InvalidArgumentException e) {
-                throw new RuntimeException(e);
-            }
+            Properties ordererProperties = networkConfig.getOrdererProperties(ordererName);
+            Properties testProp = testConfig.getEndPointProperties("orderer", ordererName);
+            ordererProperties.setProperty("clientCertFile", testProp.getProperty("clientCertFile"));
+            ordererProperties.setProperty("clientKeyFile", testProp.getProperty("clientKeyFile"));
+            networkConfig.setOrdererProperties(ordererName, ordererProperties);
         });
 
         networkConfig.getPeerNames().forEach(peerName -> {
-            try {
-                Properties peerProperties = networkConfig.getPeerProperties(peerName);
-                Properties testProp = testConfig.getEndPointProperties("peer", peerName);
-                peerProperties.setProperty("clientCertFile", testProp.getProperty("clientCertFile"));
-                peerProperties.setProperty("clientKeyFile", testProp.getProperty("clientKeyFile"));
-                networkConfig.setPeerProperties(peerName, peerProperties);
-
-            } catch (InvalidArgumentException e) {
-                throw new RuntimeException(e);
-            }
+            Properties peerProperties = networkConfig.getPeerProperties(peerName);
+            Properties testProp = testConfig.getEndPointProperties("peer", peerName);
+            peerProperties.setProperty("clientCertFile", testProp.getProperty("clientCertFile"));
+            peerProperties.setProperty("clientKeyFile", testProp.getProperty("clientKeyFile"));
+            networkConfig.setPeerProperties(peerName, peerProperties);
         });
 
         //Check if we get access to defined CAs!
@@ -151,7 +142,7 @@ public class NetworkConfigIT {
         assertEquals(caInfo.getCAName(), info.getCAName());
 
         Collection<UserInfo> registrars = caInfo.getRegistrars();
-        assertTrue(!registrars.isEmpty());
+        assertFalse(registrars.isEmpty());
         UserInfo registrar = registrars.iterator().next();
         registrar.setEnrollment(hfcaClient.enroll(registrar.getName(), registrar.getEnrollSecret()));
         MockUser mockuser = getMockUser(org.getName() + "_mock_" + System.nanoTime(), registrar.getMspId());
@@ -169,7 +160,7 @@ public class NetworkConfigIT {
         assertEquals(info.getCAName(), "");
 
         registrars = caInfo.getRegistrars();
-        assertTrue(!registrars.isEmpty());
+        assertFalse(registrars.isEmpty());
         registrar = registrars.iterator().next();
         registrar.setEnrollment(hfcaClient.enroll(registrar.getName(), registrar.getEnrollSecret()));
         mockuser = getMockUser(org.getName() + "_mock_" + System.nanoTime(), registrar.getMspId());


### PR DESCRIPTION
The connection profile tlsCaCerts element has an optional "pem" property containing one or more PEM certificates. This change allows the "pem" property to be either a string or an array of strings. For arrays, all of the contained strings are concatenated to produce the same result as including multiple certificates in a single string.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>