### PR TITLE
v1.4.11 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.11
+Fri  3 Jul 2020 14:09:39 BST
+
+* [04508d9](https://github.com/hyperledger/fabric-sdk-java/commit/04508d9) [FABJ-521] Allow arrays of PEM content in connection profile (#63)
+
 ## v1.4.9
 Tue 12 May 2020 10:30:57 BST
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.hyperledger.fabric-sdk-java</groupId>
     <artifactId>fabric-sdk-java</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.9</version>
+    <version>1.4.11</version>
     <name>fabric-java-sdk</name>
     <description>Java SDK for Hyperledger fabric project</description>
     <url>https://www.hyperledger.org/community/projects</url>

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -5,6 +5,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+if [ $# -ne 2 ]; then
+    echo 'Missing required arguments: lastReleaseCommitHash releaseVersion' >&2
+    exit 1
+fi
+
 echo "## $2\n$(date)" >> CHANGELOG.new
 echo "" >> CHANGELOG.new
 git log $1..HEAD  --oneline | grep -v Merge | sed -e "s/\[\(FAB-[0-9]*\)\]/\[\1\](https:\/\/jira.hyperledger.org\/browse\/\1\)/" -e "s/\([0-9|a-z]*\)/* \[\1\](https:\/\/github.com\/hyperledger\/fabric-sdk-java\/commit\/\1)/" >> CHANGELOG.new

--- a/src/main/java/org/hyperledger/fabric/sdk/NetworkConfig.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/NetworkConfig.java
@@ -485,6 +485,9 @@ public class NetworkConfig {
         }
 
         JsonObject channels = getJsonObject(jsonConfig, "channels");
+        if (null == channels) {
+            throw new NetworkConfigurationException("Channel configuration has no channels defined.");
+        }
 
         JsonObject jsonChannel = getJsonObject(channels, channelName);
         if (null == jsonChannel) {


### PR DESCRIPTION
The fabric-gateway-java tests picked up a bug in my cherry-picking of fixes to this branch. The fabric-sdk-java tests didn't pick it up so it was published out as 1.4.10, which is now a version we should never talk of again. Had to bump the version number in this PR to 1.4.11 and publish that version to Maven Central.