### PR TITLE
add link to FAB-1401 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You may also need to on your <span style="color:red"><b>v2.1</b> </span>  Fabric
 
 ## Known limitations and restrictions
 
-* TCerts are not supported: JIRA FAB-1401
+* TCerts are not supported: [JIRA FAB-1401](https://jira.hyperledger.org/browse/FAB-1401)
 
 ---
 


### PR DESCRIPTION
* add link to FAB-1401 like [FAB-2376](https://github.com/hyperledger/fabric-sdk-java/blob/master/README.md#chaincode-endorsement-policies) in README

Signed-off-by: Sol Kang <pdpxpd@gmail.com>