### PR TITLE
FABJ-540: Use newline separators when concatenating certificate PEM

### DIFF
--- a/src/main/java/org/hyperledger/fabric/sdk/Channel.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/Channel.java
@@ -1495,27 +1495,11 @@ public class Channel implements Serializable {
         byte[][] getTLSIntermediateCerts();
 
         default byte[] getAllTLSCerts() throws ServiceDiscoveryException {
-
-            byte[][] tlsCerts = getTLSCerts();
-            try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-                for (byte[] tlsCert : tlsCerts) {
-
-                    outputStream.write(tlsCert);
-                }
-
-                tlsCerts = getTLSIntermediateCerts();
-
-                for (byte[] tlsCert : tlsCerts) {
-
-                    outputStream.write(tlsCert);
-
-                }
-
-                return outputStream.toByteArray();
+            try {
+                return Channel.combineCerts(Arrays.asList(getTLSCerts()), Arrays.asList(getTLSIntermediateCerts()));
             } catch (IOException e) {
                 throw new ServiceDiscoveryException(e);
             }
-
         }
 
         Map<String, Peer> getEndpointMap();
@@ -1577,11 +1561,12 @@ public class Channel implements Serializable {
     private static byte[] combineCerts(Collection<byte[]>... certCollections) throws IOException {
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             for (Collection<byte[]> certCollection : certCollections) {
-
                 for (byte[] cert : certCollection) {
                     outputStream.write(cert);
+                    outputStream.write('\n');
                 }
             }
+
             return outputStream.toByteArray();
         }
     }
@@ -1603,27 +1588,11 @@ public class Channel implements Serializable {
         byte[][] getTLSIntermediateCerts();
 
         default byte[] getAllTLSCerts() throws ServiceDiscoveryException {
-
-            byte[][] tlsCerts = getTLSCerts();
-            try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-                for (byte[] tlsCert : tlsCerts) {
-
-                    outputStream.write(tlsCert);
-                }
-
-                tlsCerts = getTLSIntermediateCerts();
-
-                for (byte[] tlsCert : tlsCerts) {
-
-                    outputStream.write(tlsCert);
-
-                }
-
-                return outputStream.toByteArray();
+            try {
+                return Channel.combineCerts(Arrays.asList(getTLSCerts()), Arrays.asList(getTLSIntermediateCerts()));
             } catch (IOException e) {
                 throw new ServiceDiscoveryException(e);
             }
-
         }
 
         Map<String, Orderer> getEndpointMap();

--- a/src/main/java/org/hyperledger/fabric/sdk/NetworkConfig.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/NetworkConfig.java
@@ -831,7 +831,7 @@ public class NetworkConfig {
             }
 
             byte[] pemBytes = getJsonValueAsList(jsonTlsCaCerts.get("pem"), NetworkConfig::getJsonValueAsString).stream()
-                    .collect(Collectors.joining())
+                    .collect(Collectors.joining("\n"))
                     .getBytes();
             props.put("pemBytes", pemBytes);
         }

--- a/src/test/fixture/sdkintegration/javacc/2.1/sample1/build.gradle
+++ b/src/test/fixture/sdkintegration/javacc/2.1/sample1/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '5.1.0'
+    id 'com.github.johnrengelman.shadow' version '5.2.0'
     id 'java'
 }
 
@@ -9,12 +9,14 @@ version '1.0-SNAPSHOT'
 sourceCompatibility = 1.8
 
 repositories {
-    mavenLocal()
     mavenCentral()
+    maven {
+        url 'https://jitpack.io'
+    }
 }
 
 dependencies {
-    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.+'
+    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.+'
 }
 
 shadowJar {

--- a/src/test/java/org/hyperledger/fabric/sdk/NetworkConfigTest.java
+++ b/src/test/java/org/hyperledger/fabric/sdk/NetworkConfigTest.java
@@ -18,9 +18,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -505,9 +505,13 @@ public class NetworkConfigTest {
         Object pemBytes = caInfo.getProperties().get("pemBytes");
 
         assertTrue("Expected byte[], got " + pemBytes.getClass().getTypeName(), pemBytes instanceof byte[]);
+
         String pem = new String((byte[]) pemBytes);
         assertTrue("Missing certificate 1: " + pem, pem.contains("<1>"));
         assertTrue("Missing certificate 2:" + pem, pem.contains("<2>"));
+
+        String[] pemLines = pem.split("\n");
+        assertTrue("Expected at least 2 lines, got:\n" + Arrays.toString(pemLines), pemLines.length >= 2);
     }
 
     // TODO: ca-org1 not defined

--- a/src/test/java/org/hyperledger/fabric/sdk/SDAdditionInfoTest.java
+++ b/src/test/java/org/hyperledger/fabric/sdk/SDAdditionInfoTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2020 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.fabric.sdk;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Properties;
+
+import org.hyperledger.fabric.sdk.exception.ServiceDiscoveryException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class SDAdditionInfoTest {
+    private static byte[][] asByteArrays(String... strings) {
+        return Arrays.stream(strings)
+                .map(cert -> cert.getBytes(StandardCharsets.UTF_8))
+                .toArray(size -> new byte[size][]);
+    }
+
+    private static Channel.SDOrdererAdditionInfo newOrdererAdditionInfo(byte[][] tlsCerts, byte[][] tlsIntermediateCerts) {
+        return new Channel.SDOrdererAdditionInfo() {
+            @Override
+            public String getEndpoint() {
+                return null;
+            }
+
+            @Override
+            public Properties getProperties() {
+                return null;
+            }
+
+            @Override
+            public String getMspId() {
+                return null;
+            }
+
+            @Override
+            public Channel getChannel() {
+                return null;
+            }
+
+            @Override
+            public HFClient getClient() {
+                return null;
+            }
+
+            @Override
+            public byte[][] getTLSCerts() {
+                return tlsCerts;
+            }
+
+            @Override
+            public byte[][] getTLSIntermediateCerts() {
+                return tlsIntermediateCerts;
+            }
+
+            @Override
+            public Map<String, Orderer> getEndpointMap() {
+                return null;
+            }
+
+            @Override
+            public boolean isTLS() {
+                return false;
+            }
+        };
+    }
+
+    private static Channel.SDPeerAdditionInfo newPeerAdditionInfo(byte[][] tlsCerts, byte[][] tlsIntermediateCerts) {
+        return new Channel.SDPeerAdditionInfo() {
+            @Override
+            public String getName() {
+                return null;
+            }
+
+            @Override
+            public String getMspId() {
+                return null;
+            }
+
+            @Override
+            public String getEndpoint() {
+                return null;
+            }
+
+            @Override
+            public Channel getChannel() {
+                return null;
+            }
+
+            @Override
+            public HFClient getClient() {
+                return null;
+            }
+
+            @Override
+            public byte[][] getTLSCerts() {
+                return tlsCerts;
+            }
+
+            @Override
+            public byte[][] getTLSIntermediateCerts() {
+                return tlsIntermediateCerts;
+            }
+
+            @Override
+            public Map<String, Peer> getEndpointMap() {
+                return null;
+            }
+
+            @Override
+            public Properties getProperties() {
+                return null;
+            }
+
+            @Override
+            public boolean isTLS() {
+                return false;
+            }
+        };
+    }
+
+    @Test
+    public void testOrdererSeparatesCertificatesWithNewlines() throws ServiceDiscoveryException {
+        byte[][] tlsCerts = asByteArrays("a", "b");
+        byte[][] intermediateCerts = asByteArrays("c", "d");
+        Channel.SDOrdererAdditionInfo additionInfo = newOrdererAdditionInfo(tlsCerts, intermediateCerts);
+
+        byte[] allCerts = additionInfo.getAllTLSCerts();
+
+        String[] allCertLines = new String(allCerts, StandardCharsets.UTF_8).split("\n");
+        assertTrue("Expected at least 4 lines, got:\n" + Arrays.toString(allCertLines), allCertLines.length >= 4);
+    }
+
+    @Test
+    public void testPeerSeparatesCertificatesWithNewlines() throws ServiceDiscoveryException {
+        byte[][] tlsCerts = asByteArrays("a", "b");
+        byte[][] intermediateCerts = asByteArrays("c", "d");
+        Channel.SDPeerAdditionInfo additionInfo = newPeerAdditionInfo(tlsCerts, intermediateCerts);
+
+        byte[] allCerts = additionInfo.getAllTLSCerts();
+
+        String[] allCertLines = new String(allCerts, StandardCharsets.UTF_8).split("\n");
+        assertTrue("Expected at least 4 lines, got:\n" + Arrays.toString(allCertLines), allCertLines.length >= 4);
+    }
+}


### PR DESCRIPTION
Passing multiple concatenated X.509 certificate PEM to java.security.cert.CertificateFactory.generateCertificates() causes a parsing error. To avoid this, use a newline separator when concatenating certificate PEM bytes to avoid failures in cases where the PEM is not newline terminated.

Also fix the Java chaincode used by integration tests, which was broken by its use of a transient dependency of fabric-chaincode-shim without explicitly declaring it as a dependency.