### PR TITLE
FABJ-540: Use newline separators when concatenating certificate PEM

### DIFF
--- a/src/main/java/org/hyperledger/fabric/sdk/Channel.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/Channel.java
@@ -1546,27 +1546,11 @@ public class Channel implements Serializable {
         byte[][] getTLSIntermediateCerts();
 
         default byte[] getAllTLSCerts() throws ServiceDiscoveryException {
-
-            byte[][] tlsCerts = getTLSCerts();
-            try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-                for (byte[] tlsCert : tlsCerts) {
-
-                    outputStream.write(tlsCert);
-                }
-
-                tlsCerts = getTLSIntermediateCerts();
-
-                for (byte[] tlsCert : tlsCerts) {
-
-                    outputStream.write(tlsCert);
-
-                }
-
-                return outputStream.toByteArray();
+            try {
+                return Channel.combineCerts(Arrays.asList(getTLSCerts()), Arrays.asList(getTLSIntermediateCerts()));
             } catch (IOException e) {
                 throw new ServiceDiscoveryException(e);
             }
-
         }
 
         Map<String, Peer> getEndpointMap();
@@ -1627,11 +1611,12 @@ public class Channel implements Serializable {
     private static byte[] combineCerts(Collection<byte[]>... certCollections) throws IOException {
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             for (Collection<byte[]> certCollection : certCollections) {
-
                 for (byte[] cert : certCollection) {
                     outputStream.write(cert);
+                    outputStream.write('\n');
                 }
             }
+
             return outputStream.toByteArray();
         }
     }
@@ -1653,27 +1638,11 @@ public class Channel implements Serializable {
         byte[][] getTLSIntermediateCerts();
 
         default byte[] getAllTLSCerts() throws ServiceDiscoveryException {
-
-            byte[][] tlsCerts = getTLSCerts();
-            try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-                for (byte[] tlsCert : tlsCerts) {
-
-                    outputStream.write(tlsCert);
-                }
-
-                tlsCerts = getTLSIntermediateCerts();
-
-                for (byte[] tlsCert : tlsCerts) {
-
-                    outputStream.write(tlsCert);
-
-                }
-
-                return outputStream.toByteArray();
+            try {
+                return Channel.combineCerts(Arrays.asList(getTLSCerts()), Arrays.asList(getTLSIntermediateCerts()));
             } catch (IOException e) {
                 throw new ServiceDiscoveryException(e);
             }
-
         }
 
         Map<String, Orderer> getEndpointMap();

--- a/src/main/java/org/hyperledger/fabric/sdk/NetworkConfig.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/NetworkConfig.java
@@ -798,7 +798,7 @@ public class NetworkConfig {
             }
 
             byte[] pemBytes = getJsonValueAsList(jsonTlsCaCerts.get("pem"), NetworkConfig::getJsonValueAsString).stream()
-                    .collect(Collectors.joining())
+                    .collect(Collectors.joining("\n"))
                     .getBytes();
             props.put("pemBytes", pemBytes);
         }

--- a/src/test/java/org/hyperledger/fabric/sdk/NetworkConfigTest.java
+++ b/src/test/java/org/hyperledger/fabric/sdk/NetworkConfigTest.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.Properties;
@@ -436,9 +437,13 @@ public class NetworkConfigTest {
         Object pemBytes = caInfo.getProperties().get("pemBytes");
 
         assertTrue("Expected byte[], got " + pemBytes.getClass().getTypeName(), pemBytes instanceof byte[]);
+
         String pem = new String((byte[]) pemBytes);
         assertTrue("Missing certificate 1: " + pem, pem.contains("<1>"));
         assertTrue("Missing certificate 2:" + pem, pem.contains("<2>"));
+
+        String[] pemLines = pem.split("\n");
+        assertTrue("Expected at least 2 lines, got:\n" + Arrays.toString(pemLines), pemLines.length >= 2);
     }
 
     // TODO: ca-org1 not defined

--- a/src/test/java/org/hyperledger/fabric/sdk/SDAdditionInfoTest.java
+++ b/src/test/java/org/hyperledger/fabric/sdk/SDAdditionInfoTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2020 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.fabric.sdk;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Properties;
+
+import org.hyperledger.fabric.sdk.exception.ServiceDiscoveryException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class SDAdditionInfoTest {
+    private static byte[][] asByteArrays(String... strings) {
+        return Arrays.stream(strings)
+                .map(cert -> cert.getBytes(StandardCharsets.UTF_8))
+                .toArray(size -> new byte[size][]);
+    }
+
+    private static Channel.SDOrdererAdditionInfo newOrdererAdditionInfo(byte[][] tlsCerts, byte[][] tlsIntermediateCerts) {
+        return new Channel.SDOrdererAdditionInfo() {
+            @Override
+            public String getEndpoint() {
+                return null;
+            }
+
+            @Override
+            public Properties getProperties() {
+                return null;
+            }
+
+            @Override
+            public String getMspId() {
+                return null;
+            }
+
+            @Override
+            public Channel getChannel() {
+                return null;
+            }
+
+            @Override
+            public HFClient getClient() {
+                return null;
+            }
+
+            @Override
+            public byte[][] getTLSCerts() {
+                return tlsCerts;
+            }
+
+            @Override
+            public byte[][] getTLSIntermediateCerts() {
+                return tlsIntermediateCerts;
+            }
+
+            @Override
+            public Map<String, Orderer> getEndpointMap() {
+                return null;
+            }
+
+            @Override
+            public boolean isTLS() {
+                return false;
+            }
+        };
+    }
+
+    private static Channel.SDPeerAdditionInfo newPeerAdditionInfo(byte[][] tlsCerts, byte[][] tlsIntermediateCerts) {
+        return new Channel.SDPeerAdditionInfo() {
+            @Override
+            public String getName() {
+                return null;
+            }
+
+            @Override
+            public String getMspId() {
+                return null;
+            }
+
+            @Override
+            public String getEndpoint() {
+                return null;
+            }
+
+            @Override
+            public Channel getChannel() {
+                return null;
+            }
+
+            @Override
+            public HFClient getClient() {
+                return null;
+            }
+
+            @Override
+            public byte[][] getTLSCerts() {
+                return tlsCerts;
+            }
+
+            @Override
+            public byte[][] getTLSIntermediateCerts() {
+                return tlsIntermediateCerts;
+            }
+
+            @Override
+            public Map<String, Peer> getEndpointMap() {
+                return null;
+            }
+
+            @Override
+            public Properties getProperties() {
+                return null;
+            }
+
+            @Override
+            public boolean isTLS() {
+                return false;
+            }
+        };
+    }
+
+    @Test
+    public void testOrdererSeparatesCertificatesWithNewlines() throws ServiceDiscoveryException {
+        byte[][] tlsCerts = asByteArrays("a", "b");
+        byte[][] intermediateCerts = asByteArrays("c", "d");
+        Channel.SDOrdererAdditionInfo additionInfo = newOrdererAdditionInfo(tlsCerts, intermediateCerts);
+
+        byte[] allCerts = additionInfo.getAllTLSCerts();
+
+        String[] allCertLines = new String(allCerts, StandardCharsets.UTF_8).split("\n");
+        assertTrue("Expected at least 4 lines, got:\n" + Arrays.toString(allCertLines), allCertLines.length >= 4);
+    }
+
+    @Test
+    public void testPeerSeparatesCertificatesWithNewlines() throws ServiceDiscoveryException {
+        byte[][] tlsCerts = asByteArrays("a", "b");
+        byte[][] intermediateCerts = asByteArrays("c", "d");
+        Channel.SDPeerAdditionInfo additionInfo = newPeerAdditionInfo(tlsCerts, intermediateCerts);
+
+        byte[] allCerts = additionInfo.getAllTLSCerts();
+
+        String[] allCertLines = new String(allCerts, StandardCharsets.UTF_8).split("\n");
+        assertTrue("Expected at least 4 lines, got:\n" + Arrays.toString(allCertLines), allCertLines.length >= 4);
+    }
+}


### PR DESCRIPTION
Cherry-pick of d95e60c8cd9ab4c579a3891882f8a35fee6f5cdd from master branch.

Passing multiple concatenated X.509 certificate PEM to java.security.cert.CertificateFactory.generateCertificates() causes a parsing error. To avoid this, use a newline separator when concatenating certificate PEM bytes to avoid failures in cases where the PEM is not newline terminated.