### PR TITLE
FABJ-536 Port changes to release 2.2

### DIFF
--- a/src/main/java/org/hyperledger/fabric/sdk/NetworkConfig.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/NetworkConfig.java
@@ -834,6 +834,33 @@ public class NetworkConfig {
                     .collect(Collectors.joining("\n"))
                     .getBytes();
             props.put("pemBytes", pemBytes);
+
+            JsonObject jsonTlsClientCerts = getJsonObject(jsonTlsCaCerts, "client");
+
+            if (jsonTlsClientCerts != null) {
+
+                String keyfile = getJsonValueAsString(jsonTlsClientCerts.get("keyfile"));
+                String certfile = getJsonValueAsString(jsonTlsClientCerts.get("certfile"));
+
+                if (keyfile != null) {
+                    props.put("tlsClientKeyFile", keyfile);
+                }
+
+                if (certfile != null) {
+                    props.put("tlsClientCertFile", certfile);
+                }
+
+                String keyBytes = getJsonValueAsString(jsonTlsClientCerts.get("keyPem"));
+                String certBytes = getJsonValueAsString(jsonTlsClientCerts.get("certPem"));
+
+                if (keyBytes != null) {
+                    props.put("tlsClientKeyBytes", keyBytes.getBytes());
+                }
+
+                if (certBytes != null) {
+                    props.put("tlsClientCertBytes", certBytes.getBytes());
+                }
+            }
         }
     }
 
@@ -877,7 +904,7 @@ public class NetworkConfig {
                 if (caName != null) {
                     JsonObject jsonObject = foundCertificateAuthorities.get(caName);
                     if (jsonObject != null) {
-                        org.addCertificateAuthority(createCA(jsonObject, org));
+                        org.addCertificateAuthority(createCA(caName, jsonObject, org));
                     } else {
                         throw new NetworkConfigurationException(format("%s: Certificate Authority %s is not defined", msgPrefix, caName));
                     }
@@ -956,7 +983,7 @@ public class NetworkConfig {
     }
 
     // Creates a new CAInfo instance from a JSON object
-    private CAInfo createCA(JsonObject jsonCA, OrgInfo org) throws NetworkConfigurationException {
+    private CAInfo createCA(String name, JsonObject jsonCA, OrgInfo org) throws NetworkConfigurationException {
 
         String url = getJsonValueAsString(jsonCA.get("url"));
         Properties httpOptions = extractProperties(jsonCA, "httpOptions");
@@ -973,7 +1000,7 @@ public class NetworkConfig {
             }
         }
 
-        CAInfo caInfo = new CAInfo(org.mspId, url, regUsers, httpOptions);
+        CAInfo caInfo = new CAInfo(name, url, regUsers, httpOptions);
 
         String caName = getJsonValueAsString(jsonCA.get("caName"));
         if (caName != null) {

--- a/src/test/fixture/sdkintegration/docker-compose.yaml
+++ b/src/test/fixture/sdkintegration/docker-compose.yaml
@@ -41,6 +41,27 @@ services:
       - ./e2e-2Orgs/${FAB_CONFIG_GEN_VERS}/crypto-config/peerOrganizations/org4.example.com/msp/:/tmp/msp:ro
     container_name: ca_peerOrg2
 
+  ca2:
+    image: hyperledger/fabric-ca${IMAGE_TAG_FABRIC_CA}
+    environment:
+      - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
+      - FABRIC_CA_SERVER_CA_CERTFILE=/etc/hyperledger/fabric-ca-server-config/ca.org2.example.com-cert.pem
+      - FABRIC_CA_SERVER_CA_KEYFILE=/etc/hyperledger/fabric-ca-server-config/b59bba37975dafcc4a93984aa01d3d29b64894617db9e0c9a2d486b5273cbd27_sk
+      - FABRIC_CA_SERVER_TLS_CERTFILE=/etc/hyperledger/fabric-ca-server-config/ca.org2.example.com-cert.pem
+      - FABRIC_CA_SERVER_TLS_KEYFILE=/etc/hyperledger/fabric-ca-server-config/b59bba37975dafcc4a93984aa01d3d29b64894617db9e0c9a2d486b5273cbd27_sk
+      - FABRIC_CA_SERVER_REGISTRY_MAXENROLLMENTS=-1
+
+      - FABRIC_CA_SERVER_TLS_ENABLED=true
+      - FABRIC_CA_SERVER_TLS_CLIENTAUTH_CERTFILES=/etc/hyperledger/fabric-ca-server-config/ca.org2.example.com-cert.pem
+      - FABRIC_CA_SERVER_TLS_CLIENTAUTH_TYPE=requireandverifyclientcert
+      - FABRIC_CA_SERVER_TLS_CLIENTAUTHREQUIRED=true
+    ports:
+      - "9054:7054"
+    command: bash -c 'cp -R /tmp/msp /etc/hyperledger/fabric-ca-server; mv /etc/hyperledger/fabric-ca-server/msp/*PublicKey /etc/hyperledger/fabric-ca-server; fabric-ca-server start -b admin:adminpw ${ORG_HYPERLEDGER_FABRIC_SDKTEST_INTEGRATIONTESTS_CA_TLS} -d'
+    volumes:
+      - ./e2e-2Orgs/${FAB_CONFIG_GEN_VERS}/crypto-config/peerOrganizations/org2.example.com/ca/:/etc/hyperledger/fabric-ca-server-config:ro
+      - ./e2e-2Orgs/${FAB_CONFIG_GEN_VERS}/crypto-config/peerOrganizations/org4.example.com/msp/:/tmp/msp:ro
+    container_name: ca2_peerOrg2
 
   orderer.example.com:
     container_name: orderer.example.com

--- a/src/test/fixture/sdkintegration/network_configs/network-config-tls.yaml
+++ b/src/test/fixture/sdkintegration/network_configs/network-config-tls.yaml
@@ -172,6 +172,8 @@ organizations:
       - peer0.org2.example.com
     certificateAuthorities:
           - ca-org2
+          - ca-tls-org2
+          - ca-tls-invalid-certs-org2
 
 #
 # List of orderers to send transaction and channel create/update requests to. For the time
@@ -298,9 +300,9 @@ certificateAuthorities:
 
       # Client key and cert for TLS mutual auth with Fabric CA. If the target Fabric CA server
       # does not have TLS mutual auth turned on, then this section is not needed
-      client:
-        keyfile: path/to/tls/fabricca/certs/client/client_fabric_client-key.pem
-        certfile: path/to/tls/fabricca/certs/client/client_fabric_client.pem
+      # client:
+      #  keyfile: path/to/tls/fabricca/certs/client/client_fabric_client-key.pem
+      #  certfile: path/to/tls/fabricca/certs/client/client_fabric_client.pem
   ca-org2:
     url: https://localhost:8054
       # the properties specified under this object are passed to the 'http' client verbatim when
@@ -318,7 +320,49 @@ certificateAuthorities:
 
       # Client key and cert for TLS mutual auth with Fabric CA. If the target Fabric CA server
       # does not have TLS mutual auth turned on, then this section is not needed
+      # client:
+      #  keyfile: path/to/tls/fabricca/certs/client/client_fabric_client-key.pem
+      #  certfile: path/to/tls/fabricca/certs/client/client_fabric_client.pem
+
+  ca-tls-org2:
+    url: https://localhost:9054
+      # the properties specified under this object are passed to the 'http' client verbatim when
+      # making the request to the Fabric-CA server
+    httpOptions:
+      verify: false #must be no for testing env.
+    # Fabric-CA supports dynamic user enrollment via REST APIs. A "root" user, a.k.a registrar, is
+    # needed to enroll and invoke new users.
+    registrar: # as an array.
+      -  enrollId: admin
+         enrollSecret: adminpw
+    tlsCACerts:
+      # Comma-Separated list of paths
+      path: src/test/fixture/sdkintegration/e2e-2Orgs/v1.3/crypto-config/peerOrganizations/org2.example.com/ca/ca.org2.example.com-cert.pem
+
+      # Client key and cert for TLS mutual auth with Fabric CA. If the target Fabric CA server
+      # does not have TLS mutual auth turned on, then this section is not needed
       client:
-        keyfile: path/to/tls/fabricca/certs/client/client_fabric_client-key.pem
-        certfile: path/to/tls/fabricca/certs/client/client_fabric_client.pem
+        keyfile: src/test/fixture/sdkintegration/e2e-2Orgs/v1.3/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/5fcbc56face045c33ad213f276293bbe3c54c2e69936045af5c9c46f38b4eddc_sk
+        certfile: src/test/fixture/sdkintegration/e2e-2Orgs/v1.3/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem
+
+  ca-tls-invalid-certs-org2:
+    url: https://localhost:9054
+      # the properties specified under this object are passed to the 'http' client verbatim when
+      # making the request to the Fabric-CA server
+    httpOptions:
+      verify: false #must be no for testing env.
+    # Fabric-CA supports dynamic user enrollment via REST APIs. A "root" user, a.k.a registrar, is
+    # needed to enroll and invoke new users.
+    registrar: # as an array.
+      -  enrollId: admin
+         enrollSecret: adminpw
+    tlsCACerts:
+      # Comma-Separated list of paths
+      path: src/test/fixture/sdkintegration/e2e-2Orgs/v1.3/crypto-config/peerOrganizations/org2.example.com/ca/ca.org2.example.com-cert.pem
+
+      # Client key and cert for TLS mutual auth with Fabric CA. If the target Fabric CA server
+      # does not have TLS mutual auth turned on, then this section is not needed
+      client:
+        keyfile: src/test/fixture/sdkintegration/e2e-2Orgs/v1.3/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/581fa072e48dc2a516f664df94ea687447c071f89fc0b783b147956a08929dcc_sk
+        certfile: src/test/fixture/sdkintegration/e2e-2Orgs/v1.3/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem
 

--- a/src/test/fixture/sdkintegration/network_configs/network-config.yaml
+++ b/src/test/fixture/sdkintegration/network_configs/network-config.yaml
@@ -172,6 +172,8 @@ organizations:
       - peer0.org2.example.com
     certificateAuthorities:
           - ca-org2
+          - ca-tls-org2
+          - ca-tls-invalid-certs-org2
 
 #
 # List of orderers to send transaction and channel create/update requests to. For the time
@@ -316,3 +318,46 @@ certificateAuthorities:
       # [Optional] The optional name of the CA.
             ## caName: ca0 no ca name!
 
+  ca-tls-org2:
+    url: https://localhost:9054
+      # the properties specified under this object are passed to the 'http' client verbatim when
+      # making the request to the Fabric-CA server
+    httpOptions:
+      verify: false #must be no for testing env.
+    # Fabric-CA supports dynamic user enrollment via REST APIs. A "root" user, a.k.a registrar, is
+    # needed to enroll and invoke new users.
+    registrar: # as an array.
+      -  enrollId: admin
+         enrollSecret: adminpw
+    tlsCACerts:
+      # Comma-Separated list of paths
+      path: src/test/fixture/sdkintegration/e2e-2Orgs/v1.3/crypto-config/peerOrganizations/org2.example.com/ca/ca.org2.example.com-cert.pem
+
+      # Client key and cert for TLS mutual auth with Fabric CA. If the target Fabric CA server
+      # does not have TLS mutual auth turned on, then this section is not needed
+      client:
+        keyfile: src/test/fixture/sdkintegration/e2e-2Orgs/v1.3/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/5fcbc56face045c33ad213f276293bbe3c54c2e69936045af5c9c46f38b4eddc_sk
+        certfile: src/test/fixture/sdkintegration/e2e-2Orgs/v1.3/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/signcerts/Admin@org2.example.com-cert.pem
+
+  ca-tls-invalid-certs-org2:
+    url: https://localhost:9054
+      # the properties specified under this object are passed to the 'http' client verbatim when
+      # making the request to the Fabric-CA server
+    httpOptions:
+      verify: false #must be no for testing env.
+    # Fabric-CA supports dynamic user enrollment via REST APIs. A "root" user, a.k.a registrar, is
+    # needed to enroll and invoke new users.
+    registrar: # as an array.
+      -  enrollId: admin
+         enrollSecret: adminpw
+    tlsCACerts:
+      # Comma-Separated list of paths
+      path: src/test/fixture/sdkintegration/e2e-2Orgs/v1.3/crypto-config/peerOrganizations/org2.example.com/ca/ca.org2.example.com-cert.pem
+
+      # Client key and cert for TLS mutual auth with Fabric CA. If the target Fabric CA server
+      # does not have TLS mutual auth turned on, then this section is not needed
+      client:
+        keyfile: src/test/fixture/sdkintegration/e2e-2Orgs/v1.3/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/581fa072e48dc2a516f664df94ea687447c071f89fc0b783b147956a08929dcc_sk
+        certfile: src/test/fixture/sdkintegration/e2e-2Orgs/v1.3/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem
+
+            

--- a/src/test/java/org/hyperledger/fabric/sdkintegration/NetworkConfigIT.java
+++ b/src/test/java/org/hyperledger/fabric/sdkintegration/NetworkConfigIT.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -38,6 +39,7 @@ import org.hyperledger.fabric.sdk.InstallProposalRequest;
 import org.hyperledger.fabric.sdk.InstantiateProposalRequest;
 import org.hyperledger.fabric.sdk.NetworkConfig;
 import org.hyperledger.fabric.sdk.NetworkConfig.CAInfo;
+import org.hyperledger.fabric.sdk.NetworkConfig.OrgInfo;
 import org.hyperledger.fabric.sdk.NetworkConfig.UserInfo;
 import org.hyperledger.fabric.sdk.Orderer;
 import org.hyperledger.fabric.sdk.Peer;
@@ -56,6 +58,7 @@ import org.hyperledger.fabric.sdk.testutils.TestUtils.MockUser;
 import org.hyperledger.fabric_ca.sdk.HFCAClient;
 import org.hyperledger.fabric_ca.sdk.HFCAInfo;
 import org.hyperledger.fabric_ca.sdk.RegistrationRequest;
+import org.hyperledger.fabric_ca.sdk.exception.InfoException;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -280,6 +283,35 @@ public class NetworkConfigIT {
 
         out("testUpdate1 - done");
         out("That's all folks!");
+    }
+
+    @Test
+    public void testMutualTlsConnectivity() throws Exception {
+        OrgInfo org = networkConfig.getOrganizationInfo("Org2");
+        CAInfo caInfo = org.getCertificateAuthorities().get(0);
+
+        Optional<CAInfo> tlsCa = org.getCertificateAuthorities().stream().filter(ca -> "ca-tls-org2".equals(ca.getName())).findFirst();
+        assertTrue("Cannot find preconfigured ca-tls-org2", tlsCa.isPresent());
+
+        caInfo = tlsCa.get();
+        out("Checking connectivity to CA with mutual TLS");
+        HFCAClient hfcaClient = HFCAClient.createNewInstance(caInfo);
+        assertEquals(hfcaClient.getCAName(), caInfo.getCAName());
+        HFCAInfo info = hfcaClient.info(); //makes actual REST call.
+        assertEquals(info.getCAName(), "");
+
+        Optional<CAInfo> invalidTlsCa = org.getCertificateAuthorities().stream().filter(ca -> "ca-tls-invalid-certs-org2".equals(ca.getName())).findFirst();
+        assertTrue("Cannot find preconfigured ca-tls-invalid-certs-org2", tlsCa.isPresent());
+        caInfo = invalidTlsCa.get();
+        hfcaClient = HFCAClient.createNewInstance(caInfo);
+        assertEquals(hfcaClient.getCAName(), caInfo.getCAName());
+        try {
+            out("Checking failure of connectivity to CA with mutual TLS");
+            info = hfcaClient.info(); //makes actual REST call.
+            fail("Mutual TLS handshake should fail due to using unauthorized certs");
+        } catch (InfoException e) {
+            //Mutual TLS handshake fails as expected due to invalid certificates
+        }
     }
 
     private static void queryChaincodeForExpectedValue(HFClient client, Channel channel, final String expect, ChaincodeID chaincodeID) {


### PR DESCRIPTION
Add integration test gfor CA mutual tls. Adjust fabric client to use Hostname verifier in test mode

Signed-off-by: TsvetanG <tsvetan.georgiev@gmail.com>

Add info messages in the output when running the test

Signed-off-by: TsvetanG <tsvetan.georgiev@gmail.com>

FABJ-536 code review fixes

Signed-off-by: TsvetanG <tsvetan.georgiev@gmail.com>
Signed-off-by: Yanko Zhelyazkov <yanko@senofi.ca>