### PR TITLE
FABJ-544 Add ability to check if a transaction is the init transaction

### DIFF
--- a/src/main/java/org/hyperledger/fabric/sdk/BlockInfo.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/BlockInfo.java
@@ -465,6 +465,24 @@ public class BlockInfo {
                 return input.getArgs(index).toByteArray();
             }
 
+            /**
+             * Checks if this transaction is an init transaction.
+             * The init transaction is the one called to initialize a chaincode that requires the invocation of a
+             * function with an init flag set to true by calling either {@link TransactionRequest#setInit(boolean)}
+             * or passing --isInit if using the cli.
+             * @return boolean value indicating whether this is an init transaction
+             */
+            public boolean getChaincodeInputIsInit() {
+                if (isFiltered()) {
+                    return false;
+                }
+
+                ChaincodeInput input = transactionAction.getPayload().getChaincodeProposalPayload().
+                        getChaincodeInvocationSpec().getChaincodeInput().getChaincodeInput();
+
+                return input.getIsInit();
+            }
+
             int getEndorsementsCount = -1;
 
             public int getEndorsementsCount() {

--- a/src/test/java/org/hyperledger/fabric/sdkintegration/End2endLifecycleIT.java
+++ b/src/test/java/org/hyperledger/fabric/sdkintegration/End2endLifecycleIT.java
@@ -473,6 +473,10 @@ public class End2endLifecycleIT {
                     chaincodeName, chaincodeType, "a,", "100", "b", "300").get(testConfig.getTransactionWaitTime(), TimeUnit.SECONDS);
             assertTrue(transactionEvent.isValid());
 
+            if (initRequired) {
+                assertTrue(transactionEvent.getTransactionActionInfo(0).getChaincodeInputIsInit());
+            }
+
             transactionEvent = executeChaincode(org2Client, org2.getPeerAdmin(), org2Channel, "move",
                     false, // doInit
                     chaincodeName, chaincodeType, "a,", "b", "10").get(testConfig.getTransactionWaitTime(), TimeUnit.SECONDS);


### PR DESCRIPTION
It is useful to know if a transaction is the init transaction for example in cases when a client listening from genesis needs to wait to make sure the chaincode has been inited before invoking any chaincode functions.
There does not seem like this is being exposed anywhere at the moment, but it is a simple enough change to make.
Please consider this.

https://jira.hyperledger.org/browse/FABJ-544