### PR TITLE
FABJ-553: Include OWASP vulnerability scan in main build (release-2.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -576,8 +576,24 @@
                     </archive>
                 </configuration>
             </plugin>
-
-
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>6.2.2</version>
+                <configuration>
+                    <skipProvidedScope>true</skipProvidedScope>
+                    <skipTestScope>true</skipTestScope>
+                    <skipSystemScope>true</skipSystemScope>
+                    <failBuildOnCVSS>7</failBuildOnCVSS>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <distributionManagement>
@@ -587,28 +603,6 @@
         </snapshotRepository>
     </distributionManagement>
     <profiles>
-        <profile>
-            <id>owasp</id>
-            <!-- RUN with mvn -P owasp verify -->
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.owasp</groupId>
-                        <artifactId>dependency-check-maven</artifactId>
-                        <version>5.3.2</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                </plugins>
-            </build>
-
-        </profile>
         <profile>
             <id>release</id>
             <build>


### PR DESCRIPTION
Fail build on high severity vulnerabilities. Ignores scopes that are not propagated to dependent projects:
- provided
- test
- system