### PR TITLE
Update Chaincode Dependency

### DIFF
--- a/src/test/fixture/sdkintegration/javacc/2.1/sample1/build.gradle
+++ b/src/test/fixture/sdkintegration/javacc/2.1/sample1/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.+'
+    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.2.+'
 }
 
 shadowJar {


### PR DESCRIPTION
Set the chaincode dependency to be 2.2.+ so that it uses the latest LTS release.
2.+ will pull in any development version beta etc...

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>