### PR TITLE
Explicit dependencies in integration test chaincode (release-2.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.20</version>
+            <version>1.21</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/test/fixture/sdkintegration/javacc/2.1/sample1/build.gradle
+++ b/src/test/fixture/sdkintegration/javacc/2.1/sample1/build.gradle
@@ -17,6 +17,7 @@ repositories {
 
 dependencies {
     implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.2.+'
+    implementation 'commons-logging:commons-logging:1.2'
 }
 
 shadowJar {

--- a/src/test/fixture/sdkintegration/javacc/2.1/sample1/src/main/java/org/hyperledger/fabric/example/SimpleChaincode.java
+++ b/src/test/fixture/sdkintegration/javacc/2.1/sample1/src/main/java/org/hyperledger/fabric/example/SimpleChaincode.java
@@ -1,19 +1,16 @@
 package org.hyperledger.fabric.example;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
-import com.google.protobuf.ByteString;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hyperledger.fabric.shim.ChaincodeBase;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 import org.hyperledger.fabric.shim.ResponseUtils;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 public class SimpleChaincode extends ChaincodeBase {
-
     private static Log _logger = LogFactory.getLog(SimpleChaincode.class);
 
     @Override
@@ -112,9 +109,6 @@ public class SimpleChaincode extends ChaincodeBase {
             }
         }
         return ResponseUtils.newSuccessResponse();
-//        return   newSuccessResponse("invoke finished successfully", ByteString.copyFrom(accountFromKey + ": " + accountFromValue + " " + accountToKey + ": " + accountToValue, UTF_8).
-//
-//                        toByteArray());
     }
 
     // Deletes an entity from state
@@ -140,11 +134,10 @@ public class SimpleChaincode extends ChaincodeBase {
             return ResponseUtils.newErrorResponse(String.format("Error: state for %s is null", key));
         }
         _logger.info(String.format("Query Response:\nName: %s, Amount: %s\n", key, val));
-        return ResponseUtils.newSuccessResponse(val, ByteString.copyFrom(val, UTF_8).toByteArray());
+        return ResponseUtils.newSuccessResponse(val, val.getBytes(StandardCharsets.UTF_8));
     }
 
     public static void main(String[] args) {
         new SimpleChaincode().start(args);
     }
-
 }


### PR DESCRIPTION
Cherry-pick of fc05ef2accde5956ce930623d11d5443a4d759cf from main branch.

Resolves breakages with latest releases of the chaincode shim, where more recent Gradle versions are more strict in requiring dependencies to be specified rather than picked up as transient dependencies.

Also update commons-compress dependency to address security vulnerability.