### PR TITLE
FABJ-480 fix maxInboundMessageSize value type

### DIFF
--- a/src/main/java/org/hyperledger/fabric/sdk/NetworkConfig.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/NetworkConfig.java
@@ -815,6 +815,12 @@ public class NetworkConfig {
             props.put("grpc.NettyChannelBuilderOption.keepAliveWithoutCalls", new Object[] {Boolean.valueOf(value)});
         }
 
+        value = props.getProperty("grpc.max_inbound_message_size");
+        if (null != value) {
+            props.remove("grpc.max_inbound_message_size");
+            props.put("grpc.NettyChannelBuilderOption.maxInboundMessageSize", new Object[] {Integer.valueOf(value)});
+        }
+
         // Extract the pem details
         getTLSCerts(jsonNode, props);
 


### PR DESCRIPTION
Add peer grpc option 'grpc.max_inbound_message_size'

relate:
[FABJ-480](https://jira.hyperledger.org/browse/FABJ-480)
[FABJ-480 fix maxInboundMessageSize yaml reading](https://github.com/hyperledger/fabric-sdk-java/pull/140)