### PR TITLE
Currently, security issues have occurred in the version below log4j22…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <alpn-boot-version>8.1.7.v20160121</alpn-boot-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jacoco.version>0.8.5</jacoco.version>
-        <log4j.version>2.13.3</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
         <org.hyperledger.fabric.sdktest.ITSuite>IntegrationSuite.java</org.hyperledger.fabric.sdktest.ITSuite>
         <gpg.executable>gpg2</gpg.executable>
     </properties>


### PR DESCRIPTION
….15.0.

In version 2.2 of hyperledger-fabric-sdk java, log4j2 was updated to version 2.15.0. It would be nice to update all versions of hyperledger-fabric-sdk java 1.4.x to log4j2 2.15.0.

Please update to log42.16.0 version due to an issue in log4j 2.15.0 version.

log4j Reference page
https://logging.apache.org/log4j/2.x/security.html