### PR TITLE
Update dependencies (release-1.4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,18 +28,18 @@
         <tag>fabric-sdk-java-1.0</tag>
     </scm>
     <properties>
-        <grpc.version>1.35.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
-        <protobuf.version>3.12.4</protobuf.version>
-        <bouncycastle.version>1.62</bouncycastle.version>
+        <grpc.version>1.43.1</grpc.version>
+        <protobuf.version>3.19.1</protobuf.version> <!-- Must match version used by grpc-protobuf -->
+        <bouncycastle.version>1.70</bouncycastle.version>
         <httpclient.version>4.5.13</httpclient.version>
         <javadoc.version>3.2.0</javadoc.version>
         <skipITs>true</skipITs>
         <alpn-boot-version>8.1.7.v20160121</alpn-boot-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jacoco.version>0.8.5</jacoco.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <org.hyperledger.fabric.sdktest.ITSuite>IntegrationSuite.java</org.hyperledger.fabric.sdktest.ITSuite>
-        <gpg.executable>gpg2</gpg.executable>
+        <gpg.executable>gpg</gpg.executable>
     </properties>
 
     <reporting>
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.4</version>
+            <version>1.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -145,7 +145,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.11.0</version>
         </dependency>
 
        <dependency>
@@ -182,7 +182,6 @@
             <scope>test</scope>
         </dependency>
 
-
         <!-- https://mvnrepository.com/artifact/org.glassfish/javax.json -->
         <dependency>
             <groupId>org.glassfish</groupId>
@@ -209,7 +208,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.26</version>
+            <version>1.30</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.miracl.milagro.amcl/milagro-crypto-java -->
@@ -550,8 +549,6 @@
                     </archive>
                 </configuration>
             </plugin>
-
-
         </plugins>
     </build>
     <distributionManagement>

--- a/src/test/java/org/hyperledger/fabric/sdk/helper/UtilsTest.java
+++ b/src/test/java/org/hyperledger/fabric/sdk/helper/UtilsTest.java
@@ -15,6 +15,7 @@ package org.hyperledger.fabric.sdk.helper;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -204,8 +205,7 @@ public class UtilsTest {
     }
 
     // Test compressing a non-existent directory
-    // Note that this currently throws an IllegalArgumentException, and not an IOException!
-    @Test (expected = IllegalArgumentException.class)
+    @Test (expected = UncheckedIOException.class)
     public void testGenerateTarGzNoDirectory() throws Exception {
         File rootDir = tempFolder.getRoot().getAbsoluteFile();
         File nonExistentDir = new File(rootDir, "temp");


### PR DESCRIPTION
Includes a fix to another security vulnerability (CVE-2021-44832) in Log4j.