### PR TITLE
Listen to private data in the events

### DIFF
--- a/src/main/java/org/hyperledger/fabric/sdk/BlockInfo.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/BlockInfo.java
@@ -38,47 +38,62 @@ import static java.lang.String.format;
  * BlockInfo contains the data from a {@link Block}
  */
 public class BlockInfo {
-    private final BlockDeserializer block; //can be only one or the other.
+    private final BlockDeserializer block; // block deserializer
     private final EventsPackage.FilteredBlock filteredBlock;
+    private final EventsPackage.BlockAndPrivateData blockAndPrivateData;
+    private final Type type;
 
     BlockInfo(Block block) {
-
         filteredBlock = null;
+        blockAndPrivateData = null;
         this.block = new BlockDeserializer(block);
+        type = Type.BLOCK;
     }
 
     BlockInfo(EventsPackage.DeliverResponse resp) {
+        final EventsPackage.DeliverResponse.TypeCase responseType = resp.getTypeCase();
 
-        final EventsPackage.DeliverResponse.TypeCase type = resp.getTypeCase();
-
-        if (type == EventsPackage.DeliverResponse.TypeCase.BLOCK) {
+        if (responseType == EventsPackage.DeliverResponse.TypeCase.BLOCK) {
             final Block respBlock = resp.getBlock();
-            filteredBlock = null;
             if (respBlock == null) {
                 throw new AssertionError("DeliverResponse type block but block is null");
             }
+            filteredBlock = null;
+            blockAndPrivateData = null;
             this.block = new BlockDeserializer(respBlock);
-        } else if (type == EventsPackage.DeliverResponse.TypeCase.FILTERED_BLOCK) {
+            type = Type.BLOCK;
+        } else if (responseType == EventsPackage.DeliverResponse.TypeCase.FILTERED_BLOCK) {
             filteredBlock = resp.getFilteredBlock();
-            block = null;
             if (filteredBlock == null) {
                 throw new AssertionError("DeliverResponse type filter block but filter block is null");
             }
-
+            block = null;
+            blockAndPrivateData = null;
+            type = Type.FILTERED_BLOCK;
+        } else if (responseType == EventsPackage.DeliverResponse.TypeCase.BLOCK_AND_PRIVATE_DATA) {
+            blockAndPrivateData = resp.getBlockAndPrivateData();
+            if (blockAndPrivateData == null || blockAndPrivateData.getBlock() == null) {
+                throw new AssertionError("DeliverResponse type block and private data is null");
+            }
+            filteredBlock = null;
+            block = new BlockDeserializer(blockAndPrivateData.getBlock());
+            type = Type.BLOCK_WITH_PRIVATE_DATA;
         } else {
-            throw new AssertionError(format("DeliverResponse type has unexpected type: %s, %d", type.name(), type.getNumber()));
+            throw new AssertionError(format("DeliverResponse type has unexpected type: %s, %d", responseType.name(), responseType.getNumber()));
         }
 
     }
 
     public boolean isFiltered() {
-        if (filteredBlock == null && block == null) {
-            throw new AssertionError("Both block and filter is null.");
-        }
-        if (filteredBlock != null && block != null) {
-            throw new AssertionError("Both block and filter are set.");
-        }
-        return filteredBlock != null;
+        return type == Type.FILTERED_BLOCK;
+    }
+
+    /**
+     * Block type information. The block type determines the values returned by {@link #getBlock()}, {@link #getFilteredBlock()}
+     * and {@link #getBlockAndPrivateData()}.
+     */
+    public Type getType() {
+        return type;
     }
 
     public String getChannelId() throws InvalidProtocolBufferException {
@@ -86,17 +101,27 @@ public class BlockInfo {
     }
 
     /**
-     * @return the raw {@link Block}
+     * @return If {@link #getType()} is {@link Type#BLOCK} or {@link Type#BLOCK_WITH_PRIVATE_DATA}, the raw {@link Block};
+     * otherwise {@code null}.
      */
     public Block getBlock() {
         return isFiltered() ? null : block.getBlock();
     }
 
     /**
-     * @return the raw {@link org.hyperledger.fabric.protos.peer.EventsPackage.FilteredBlock}
+     * @return If {@link #getType()} is {@link Type#FILTERED_BLOCK}, the raw {@link EventsPackage.FilteredBlock};
+     * otherwise {@code null}.
      */
     public EventsPackage.FilteredBlock getFilteredBlock() {
-        return !isFiltered() ? null : filteredBlock;
+        return filteredBlock;
+    }
+
+    /**
+     * @return If {@link #getType()} is {@link Type#BLOCK_WITH_PRIVATE_DATA}, the raw {@link EventsPackage.BlockAndPrivateData};
+     * otherwise {@code null}.
+     */
+    public EventsPackage.BlockAndPrivateData getBlockAndPrivateData() {
+        return blockAndPrivateData;
     }
 
     /**
@@ -177,6 +202,26 @@ public class BlockInfo {
             transactionCount = ltransactionCount;
         }
         return transactionCount;
+    }
+
+    /**
+     * Block event type information.
+     */
+    public enum Type {
+        FILTERED_BLOCK("Filtered Block"),
+        BLOCK("Block"),
+        BLOCK_WITH_PRIVATE_DATA("Block and Private Data");
+
+        final String description;
+
+        Type(final String description) {
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return this.description;
+        }
     }
 
     /**

--- a/src/main/java/org/hyperledger/fabric/sdk/Channel.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/Channel.java
@@ -6415,12 +6415,12 @@ public class Channel implements Serializable {
         protected Boolean newest = true;
         protected Long startEvents;
         protected Long stopEvents = Long.MAX_VALUE;
-        protected boolean registerEventsForFilteredBlocks = false;
+        protected BlockInfo.Type eventType = BlockInfo.Type.BLOCK;
 
         @Override
         public String toString() {
             StringBuilder sb = new StringBuilder(1000);
-            sb.append("PeerOptions( " + format("newest: %s, startEvents: %s, stopEvents: %s, registerEventsForFilteredBlocks: %s", "" + newest, "" + startEvents, "" + stopEvents, registerEventsForFilteredBlocks));
+            sb.append("PeerOptions( " + format("newest: %s, startEvents: %s, stopEvents: %s, eventType: %s", "" + newest, "" + startEvents, "" + stopEvents, eventType));
 
             if (peerRoles != null && !peerRoles.isEmpty()) {
                 sb.append(", PeerRoles:[");
@@ -6437,12 +6437,12 @@ public class Channel implements Serializable {
         }
 
         /**
-         * Is the peer eventing service registered for filtered blocks
+         * Returns requested event type
          *
-         * @return true if filtered blocks will be returned by the peer eventing service.
+         * @return enum value of the event type
          */
-        public boolean isRegisterEventsForFilteredBlocks() {
-            return registerEventsForFilteredBlocks;
+        BlockInfo.Type getEventType() {
+            return this.eventType;
         }
 
         /**
@@ -6451,7 +6451,17 @@ public class Channel implements Serializable {
          * @return the PeerOptions instance.
          */
         public PeerOptions registerEventsForFilteredBlocks() {
-            registerEventsForFilteredBlocks = true;
+            this.eventType = BlockInfo.Type.FILTERED_BLOCK;
+            return this;
+        }
+
+        /**
+         * Register the peer eventing services to return private data maps with the blocks.
+         *
+         * @return the PeerOptions instance.
+         */
+        public PeerOptions registerEventsForPrivateData() {
+            this.eventType = BlockInfo.Type.BLOCK_WITH_PRIVATE_DATA;
             return this;
         }
 
@@ -6461,7 +6471,7 @@ public class Channel implements Serializable {
          * @return the PeerOptions instance.
          */
         public PeerOptions registerEventsForBlocks() {
-            registerEventsForFilteredBlocks = false;
+            this.eventType = BlockInfo.Type.BLOCK;
             return this;
         }
 

--- a/src/test/java/org/hyperledger/fabric/sdk/NetworkConfigTest.java
+++ b/src/test/java/org/hyperledger/fabric/sdk/NetworkConfigTest.java
@@ -470,7 +470,7 @@ public class NetworkConfigTest {
         for (Peer peer : channel.getPeers()) {
             Channel.PeerOptions peersOptions = channel.getPeersOptions(peer);
             assertNotNull(peersOptions);
-            assertTrue(peersOptions.isRegisterEventsForFilteredBlocks());
+            assertEquals(peersOptions.getEventType(), BlockInfo.Type.FILTERED_BLOCK);
             assertEquals(expectedStartEvents, peersOptions.startEvents);
             assertEquals(expectedStopEvents, peersOptions.stopEvents);
             assertEquals(expectmaxMessageSizePeer, peer.getProperties().get("grpc.NettyChannelBuilderOption.maxInboundMessageSize"));

--- a/src/test/java/org/hyperledger/fabric/sdkintegration/End2endAndBackAgainIT.java
+++ b/src/test/java/org/hyperledger/fabric/sdkintegration/End2endAndBackAgainIT.java
@@ -889,8 +889,8 @@ public class End2endAndBackAgainIT {
                     assertNull(blockEvent.getBlock()); // should not have raw block event.
                     assertNotNull(blockEvent.getFilteredBlock()); // should have raw filtered block.
                 } else {
-                    assertNotNull(blockEvent.getBlock()); // should not have raw block event.
-                    assertNull(blockEvent.getFilteredBlock()); // should have raw filtered block.
+                    assertNotNull(blockEvent.getBlock()); // should have raw block event.
+                    assertNull(blockEvent.getFilteredBlock()); // should not have raw filtered block.
                 }
 
                 assertEquals(replayTestChannel.getName(), blockEvent.getChannelId());

--- a/src/test/java/org/hyperledger/fabric/sdkintegration/PrivateDataIT.java
+++ b/src/test/java/org/hyperledger/fabric/sdkintegration/PrivateDataIT.java
@@ -19,19 +19,28 @@ package org.hyperledger.fabric.sdkintegration;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
+import org.hyperledger.fabric.protos.ledger.rwset.Rwset;
 import org.hyperledger.fabric.sdk.BlockEvent;
+import org.hyperledger.fabric.sdk.BlockInfo;
+import org.hyperledger.fabric.sdk.BlockchainInfo;
 import org.hyperledger.fabric.sdk.ChaincodeCollectionConfiguration;
+import org.hyperledger.fabric.sdk.ChaincodeEvent;
 import org.hyperledger.fabric.sdk.ChaincodeID;
 import org.hyperledger.fabric.sdk.ChaincodeResponse.Status;
 import org.hyperledger.fabric.sdk.Channel;
@@ -46,6 +55,7 @@ import org.hyperledger.fabric.sdk.TestConfigHelper;
 import org.hyperledger.fabric.sdk.TransactionProposalRequest;
 import org.hyperledger.fabric.sdk.TransactionRequest;
 import org.hyperledger.fabric.sdk.User;
+import org.hyperledger.fabric.sdk.exception.InvalidArgumentException;
 import org.hyperledger.fabric.sdk.exception.ProposalException;
 import org.hyperledger.fabric.sdk.exception.TransactionEventException;
 import org.hyperledger.fabric.sdk.security.CryptoSuite;
@@ -56,9 +66,13 @@ import org.junit.Test;
 
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hyperledger.fabric.sdk.BlockInfo.EnvelopeType.TRANSACTION_ENVELOPE;
+import static org.hyperledger.fabric.sdk.Channel.PeerOptions.createPeerOptions;
 import static org.hyperledger.fabric.sdk.testutils.TestUtils.resetConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -195,6 +209,23 @@ public class PrivateDataIT {
 
             }
             assertEquals(expect, got);
+
+            byte[] replayChannelBytes = barChannel.serializeChannel();
+            barChannel.shutdown(true);
+
+            Channel replayChannel = client.deSerializeChannel(replayChannelBytes);
+            out("doing testPeerServiceEventingReplay,0,-1");
+            testPeerServiceEventingReplay(client, replayChannel, 0L, -1L, expect);
+
+            //Now do it again starting at block 1
+            replayChannel = client.deSerializeChannel(replayChannelBytes);
+            out("doing testPeerServiceEventingReplay,1,-1");
+            testPeerServiceEventingReplay(client, replayChannel, 1L, -1L, expect);
+
+            //Now do it again starting at block 2 to 3
+            replayChannel = client.deSerializeChannel(replayChannelBytes);
+            out("doing testPeerServiceEventingReplay,2,3");
+            testPeerServiceEventingReplay(client, replayChannel, 2L, 3L, expect);
         }
 
         out("That's all folks!");
@@ -469,6 +500,179 @@ public class PrivateDataIT {
 
         }
 
+    }
+
+    /**
+     * This code test the replay feature of the new peer event services.
+     * Instead of the default of starting the eventing peer to retrieve the newest block it sets it
+     * retrieve starting from the start parameter.
+     *
+     * @param client hlf client that con connect to the Fabric network
+     * @param replayTestChannel channel object to subscribe and replay events
+     * @param start index from where block events are to be read
+     * @param stop index upto where the block events are to be read
+     * @throws InvalidArgumentException in case of an error.
+     */
+    private void testPeerServiceEventingReplay(HFClient client, Channel replayTestChannel, final long start, final long stop, Set<String> collections) throws InvalidArgumentException {
+
+        assertFalse(replayTestChannel.isInitialized()); //not yet initialized
+        assertFalse(replayTestChannel.isShutdown()); // not yet shutdown.
+
+        //Remove all peers just have one ledger peer and one eventing peer.
+        List<Peer> savedPeers = new ArrayList<>(replayTestChannel.getPeers());
+        for (Peer peer : savedPeers) {
+            replayTestChannel.removePeer(peer);
+        }
+        assertTrue(savedPeers.size() > 1); //need at least two
+        Peer eventingPeer = savedPeers.remove(0);
+        eventingPeer = client.newPeer(eventingPeer.getName(), eventingPeer.getUrl(), eventingPeer.getProperties());
+        Peer ledgerPeer = savedPeers.remove(0);
+        ledgerPeer = client.newPeer(ledgerPeer.getName(), ledgerPeer.getUrl(), ledgerPeer.getProperties());
+
+        assertTrue(replayTestChannel.getPeers().isEmpty()); // no more peers.
+        assertTrue(replayTestChannel.getPeers(EnumSet.of(Peer.PeerRole.CHAINCODE_QUERY, Peer.PeerRole.ENDORSING_PEER)).isEmpty()); // just checking :)
+        assertTrue(replayTestChannel.getPeers(EnumSet.of(Peer.PeerRole.LEDGER_QUERY)).isEmpty()); // just checking
+
+        assertNotNull(client.getChannel(replayTestChannel.getName())); // should be known by client.
+
+        // Register for receiving blocks with the private data
+        final Channel.PeerOptions eventingPeerOptions = createPeerOptions().setPeerRoles(EnumSet.of(Peer.PeerRole.EVENT_SOURCE));
+        eventingPeerOptions.registerEventsForPrivateData();
+
+        if (-1L == stop) { //the height of the blockchain
+
+            replayTestChannel.addPeer(eventingPeer, eventingPeerOptions.startEvents(start)); // Eventing peer start getting blocks from block 0
+        } else {
+            replayTestChannel.addPeer(eventingPeer, eventingPeerOptions
+                    .startEvents(start).stopEvents(stop)); // Eventing peer start getting blocks from block 0
+        }
+        //add a ledger peer
+        replayTestChannel.addPeer(ledgerPeer, createPeerOptions().setPeerRoles(EnumSet.of(Peer.PeerRole.LEDGER_QUERY)));
+
+        CompletableFuture<Long> done = new CompletableFuture<>(); // future to set when done.
+        // some variable used by the block listener being set up.
+        final AtomicLong bcount = new AtomicLong(0);
+        final AtomicLong stopValue = new AtomicLong(stop == -1L ? Long.MAX_VALUE : stop);
+        final Channel finalChannel = replayTestChannel;
+
+        final Map<Long, BlockEvent> blockEvents = Collections.synchronizedMap(new HashMap<>(100));
+
+        final String blockListenerHandle = replayTestChannel.registerBlockListener(blockEvent -> { // register a block listener
+
+            try {
+                final long blockNumber = blockEvent.getBlockNumber();
+                BlockEvent seen = blockEvents.put(blockNumber, blockEvent);
+                assertNull(format("Block number %d seen twice", blockNumber), seen);
+
+                assertEquals(format("Wrong type of block seen block number %d. expected block with private data but got %s",
+                                blockNumber, blockEvent.getType()), BlockInfo.Type.BLOCK_WITH_PRIVATE_DATA, blockEvent.getType());
+                final long count = bcount.getAndIncrement(); //count starts with 0 not 1 !
+
+                if (count == 0 && stop == -1L) {
+                    final BlockchainInfo blockchainInfo = finalChannel.queryBlockchainInfo();
+
+                    long lh = blockchainInfo.getHeight();
+                    stopValue.set(lh - 1L);  // blocks 0L 9L are on chain height 10 .. stop on 9
+                    if (bcount.get() + start > stopValue.longValue()) { // test with latest count.
+                        done.complete(bcount.get()); // report back latest count.
+                    }
+
+                } else {
+                    if (bcount.longValue() + start > stopValue.longValue()) {
+                        done.complete(count);
+                    }
+                }
+            } catch (AssertionError | Exception e) {
+                e.printStackTrace();
+                done.completeExceptionally(e);
+            }
+
+        });
+
+        try {
+            replayTestChannel.initialize(); // start it all up.
+            done.get(30, TimeUnit.SECONDS); // give a timeout here.
+            Thread.sleep(1000); // sleep a little to see if more blocks trickle in .. they should not
+            replayTestChannel.unregisterBlockListener(blockListenerHandle);
+
+            final long expectNumber = stopValue.longValue() - start + 1L; // Start 2 and stop is 3  expect 2
+
+            assertEquals(format("Didn't get number we expected %d but got %d block events. Start: %d, end: %d, height: %d",
+                    expectNumber, blockEvents.size(), start, stop, stopValue.longValue()), expectNumber, blockEvents.size());
+
+            for (long i = stopValue.longValue(); i >= start; i--) { //make sure all are there.
+                final BlockEvent blockEvent = blockEvents.get(i);
+                assertNotNull(format("Missing block event for block number %d. Start= %d", i, start), blockEvent);
+            }
+
+            // lightweight test just see if we get reasonable values for traversing the block.
+
+            int transactionEventCounts = 0;
+            int chaincodeEventsCounts = 0;
+
+            for (long i = stopValue.longValue(); i >= start; i--) {
+
+                final BlockEvent blockEvent = blockEvents.get(i);
+                assertEquals(BlockInfo.Type.BLOCK_WITH_PRIVATE_DATA, blockEvent.getType()); // check again
+
+                assertNotNull(blockEvent.getBlock()); // should have block.
+                assertNull(blockEvent.getFilteredBlock()); // should not have filtered block.
+                assertNotNull(blockEvent.getBlockAndPrivateData()); // should have block and private data.
+                Map<Long, Rwset.TxPvtReadWriteSet> privateDataMap = blockEvent.getBlockAndPrivateData().getPrivateDataMapMap();
+                assertNotNull(privateDataMap); // should have private data
+
+                // get all the collections from the privateDataMap
+                // collection should be set already
+                for (Map.Entry<Long, Rwset.TxPvtReadWriteSet> privateData : privateDataMap.entrySet()) {
+                    Rwset.TxPvtReadWriteSet pvtReadWriteSet = privateData.getValue();
+                    for (Rwset.NsPvtReadWriteSet nsPvtReadWriteSet : pvtReadWriteSet.getNsPvtRwsetList()) {
+                        for (Rwset.CollectionPvtReadWriteSet pvtReadWriteSet1 : nsPvtReadWriteSet.getCollectionPvtRwsetList()) {
+                            assertTrue(collections.contains(pvtReadWriteSet1.getCollectionName()));
+                        }
+                    }
+                }
+
+                assertEquals(replayTestChannel.getName(), blockEvent.getChannelId());
+
+                for (BlockInfo.EnvelopeInfo envelopeInfo : blockEvent.getEnvelopeInfos()) {
+                    if (envelopeInfo.getType() == TRANSACTION_ENVELOPE) {
+
+                        BlockInfo.TransactionEnvelopeInfo transactionEnvelopeInfo = (BlockInfo.TransactionEnvelopeInfo) envelopeInfo;
+                        assertTrue(envelopeInfo.isValid()); // only have valid blocks.
+                        assertEquals(envelopeInfo.getValidationCode(), 0);
+
+                        ++transactionEventCounts;
+                        for (BlockInfo.TransactionEnvelopeInfo.TransactionActionInfo ta : transactionEnvelopeInfo.getTransactionActionInfos())  {
+                            ChaincodeEvent event = ta.getEvent();
+                            if (event != null) {
+                                assertNotNull(event.getChaincodeId());
+                                assertNotNull(event.getEventName());
+                                chaincodeEventsCounts++;
+                            }
+
+                        }
+
+                    } else {
+                        assertEquals("Only non transaction block should be block 0.", blockEvent.getBlockNumber(), 0);
+
+                    }
+
+                }
+
+            }
+
+            assertTrue(transactionEventCounts > 0);
+
+            if (expectNumber > 4) { // this should be enough blocks with CC events.
+
+                assertTrue(chaincodeEventsCounts > 0);
+            }
+
+            replayTestChannel.shutdown(true); //all done.
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
     }
 
     private void queryChaincodeForExpectedValue(HFClient client, Channel channel, final String expect, ChaincodeID chaincodeID) {


### PR DESCRIPTION
Cherry-pick of 44edbe517d3c07df7aeff93f2570965749cd14a7 from main branch.

* Listen to private data in the events
* Add integration tests for the new PDC events feature
* Expose enum for block event type instead of multiple boolean getters to determine event type.