### PR TITLE
Run vulnerability scan only in the nightly build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,11 +21,48 @@ variables:
   GOPATH: $(Build.Repository.LocalPath)/src/test/fixture
   FABRIC_VERSION: 2.2
 
-pool:
-  vmImage: 'ubuntu-20.04'
+stages:
+  - stage: Test
+    displayName: Setup and Run Tests
+    dependsOn: [ ]
+    jobs:
+      - job: Integration
+        displayName: Integration tests
+        pool:
+          vmImage: ubuntu-20.04
+        strategy:
+          matrix:
+            Java8:
+              JAVAVER: 8
+            Java11:
+              JAVAVER: 11
+            Java17:
+              JAVAVER: 17
+        steps:
+          - task: JavaToolInstaller@0
+            inputs:
+              versionSpec: $(JAVAVER)
+              jdkArchitectureOption: 'x64'
+              jdkSourceOption: 'PreInstalled'
+          - script: ./scripts/run-integration-tests.sh
+            displayName: Run integration tests
 
-jobs:
-  - job: Integration
-    steps:
-      - script: ./scripts/run-integration-tests.sh
-        displayName: Run Tests
+  # Only run security vulnerability scan on scheduled builds
+  - stage: Scan
+    dependsOn: [ ]
+    condition: eq(variables['Build.Reason'], 'Schedule')
+    jobs:
+      - job: ScanDependencies
+        pool:
+          vmImage: ubuntu-20.04
+        dependsOn: [ ]
+        timeoutInMinutes: 60
+        steps:
+          - task: Maven@3
+            displayName: 'Maven dependency-check'
+            inputs:
+              mavenPomFile: 'pom.xml'
+              goals: '-P owasp dependency-check:check'
+          - publish: $(System.DefaultWorkingDirectory)/target/dependency-check-report.html
+            artifact: DependencyCheck
+            displayName: 'Upload dependency-check report'

--- a/dependencies-suppressions.xml
+++ b/dependencies-suppressions.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress>
-        <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.instrumentation/opentelemetry\-grpc\-1\.6@.*$</packageUrl>
-        <cve>CVE-2020-7768</cve>
-    </suppress>
-</suppressions>

--- a/dependency-suppressions.xml
+++ b/dependency-suppressions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        CVE was reported against @grpc/grpc-js npm package, not Java
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.instrumentation/opentelemetry\-grpc\-1\.6@.*$</packageUrl>
+        <cve>CVE-2020-7768</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        CVE was reported in version 1.4-M1 to 1.4-RC and fixed in version 1.4.0
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib\-common@1\.4\.0$</packageUrl>
+        <cve>CVE-2020-15824</cve>
+    </suppress>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -422,7 +422,7 @@
                         <link>http://docs.oracle.com/javase/8/docs/api/</link>
                     </links>
                     <additionalJOptions>
-                        <additionalJOption>--no-module-directories</additionalJOption>
+                        <additionalJOption>${additionalJavadocOpts}</additionalJOption>
                     </additionalJOptions>
                 </configuration>
             </plugin>
@@ -636,27 +636,6 @@
                     </archive>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-                <version>6.5.3</version>
-                <configuration>
-                    <skipProvidedScope>true</skipProvidedScope>
-                    <skipTestScope>true</skipTestScope>
-                    <skipSystemScope>true</skipSystemScope>
-                    <failBuildOnCVSS>7</failBuildOnCVSS>
-                    <suppressionFiles>
-                        <suppressionFile>dependencies-suppressions.xml</suppressionFile>
-                    </suppressionFiles>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <distributionManagement>
@@ -666,6 +645,44 @@
         </snapshotRepository>
     </distributionManagement>
     <profiles>
+        <profile>
+            <id>owasp</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>7.0.1</version>
+                        <configuration>
+                            <skipProvidedScope>true</skipProvidedScope>
+                            <skipTestScope>true</skipTestScope>
+                            <skipSystemScope>true</skipSystemScope>
+                            <failBuildOnCVSS>7</failBuildOnCVSS>
+                            <suppressionFiles>
+                                <suppressionFile>dependency-suppressions.xml</suppressionFile>
+                            </suppressionFiles>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>javadoc-no-module-directories</id>
+            <activation>
+                <jdk>[11,13)</jdk>
+            </activation>
+            <properties>
+                <additionalJavadocOpts>--no-module-directories</additionalJavadocOpts>
+            </properties>
+        </profile>
         <profile>
             <id>release</id>
             <build>
@@ -745,7 +762,7 @@
                                 <link>http://docs.oracle.com/javase/8/docs/api/</link>
                             </links>
                             <additionalJOptions>
-                                <additionalJOption>--no-module-directories</additionalJOption>
+                                <additionalJOption>${additionalJavadocOpts}</additionalJOption>
                             </additionalJOptions>
                         </configuration>
                         <executions>


### PR DESCRIPTION
- Update scan version
- Add suppression of vulnerability false positive
- Fix Javadoc build for later Java versions
- Run integration tests with Java 8, 11 and 17

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>