### PR TITLE
upgrade opentelemetry version to 1.12.0 (release-2.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,14 +80,14 @@
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
-                <version>1.9.1</version>
+                <version>1.12.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry.instrumentation</groupId>
                 <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
-                <version>1.9.2-alpha</version>
+                <version>1.12.0-alpha</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/org/hyperledger/fabric/sdk/helper/Config.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/helper/Config.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.OpenTelemetrySdkBuilder;
-import io.opentelemetry.sdk.autoconfigure.OpenTelemetrySdkAutoConfiguration;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -247,7 +247,11 @@ public class Config {
 
             }
 
-            openTelemetry = OpenTelemetrySdkAutoConfiguration.initialize(false);
+            openTelemetry = AutoConfiguredOpenTelemetrySdk
+                .builder()
+                .setResultAsGlobal(false)
+                .build()
+                .getOpenTelemetrySdk();
         }
 
     }


### PR DESCRIPTION
Cherry-pick of 4e16cadfd6098d1cd79fe28e80f0ddd820267e69 from main branch.

Signed-off-by: Danilo Faria <danilo@digitalasset.com>