### PR TITLE
Address security vulnerability CVE-2022-25647

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,11 +137,6 @@
             <version>${protobuf.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java-util</artifactId>
-            <version>${protobuf.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
             <version>${bouncycastle.version}</version>
@@ -652,7 +647,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>7.0.1</version>
+                        <version>7.1.0</version>
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipTestScope>true</skipTestScope>

--- a/src/main/java/org/hyperledger/fabric/sdk/transaction/ProtoUtils.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/transaction/ProtoUtils.java
@@ -23,7 +23,6 @@ import javax.xml.bind.DatatypeConverter;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
-import com.google.protobuf.util.Timestamps;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hyperledger.fabric.protos.common.Common;
@@ -225,13 +224,15 @@ public final class ProtoUtils {
     }
 
     public static Date getDateFromTimestamp(Timestamp timestamp) {
-        return new Date(Timestamps.toMillis(timestamp));
+        return Date.from(Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos()));
     }
 
     static Timestamp getTimestampFromDate(Date date) {
-        long millis = date.getTime();
-        return Timestamp.newBuilder().setSeconds(millis / 1000)
-                .setNanos((int) ((millis % 1000) * 1000000)).build();
+        Instant instant = date.toInstant();
+        return Timestamp.newBuilder()
+                .setSeconds(instant.getEpochSecond())
+                .setNanos(instant.getNano())
+                .build();
     }
 
     public static Common.Envelope createSeekInfoEnvelope(TransactionContext transactionContext, Ab.SeekInfo seekInfo, byte[] tlsCertHash) throws CryptoException, InvalidArgumentException {


### PR DESCRIPTION
- Remove dependency on protobuf-java-util, since it has a dependency on gson.
- Remove use of gson in code, despite it not being declared as a dependency.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>