### PR TITLE
Disabled scehduled security vulnerability scan (release-2.2)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,23 +46,3 @@ stages:
               jdkSourceOption: 'PreInstalled'
           - script: ./scripts/run-integration-tests.sh
             displayName: Run integration tests
-
-  # Only run security vulnerability scan on scheduled builds
-  - stage: Scan
-    dependsOn: [ ]
-    condition: eq(variables['Build.Reason'], 'Schedule')
-    jobs:
-      - job: ScanDependencies
-        pool:
-          vmImage: ubuntu-20.04
-        dependsOn: [ ]
-        timeoutInMinutes: 60
-        steps:
-          - task: Maven@3
-            displayName: 'Maven dependency-check'
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: '-P owasp dependency-check:check'
-          - publish: $(System.DefaultWorkingDirectory)/target/dependency-check-report.html
-            artifact: DependencyCheck
-            displayName: 'Upload dependency-check report'

--- a/dependency-suppressions.xml
+++ b/dependency-suppressions.xml
@@ -14,4 +14,11 @@
         <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib\-common@1\.4\.0$</packageUrl>
         <cve>CVE-2020-15824</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Vulnerability is reported against an AWS hotfix, not the Apache log4j package
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-.*$</packageUrl>
+        <cve>CVE-2022-33915</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
This is already covered by the scheduled security scans that run against fabric-gateway-java and having it run here just adds maintenance overhead.