### PR TITLE
Update dependencies to support Apple silicon (M1 / arm64)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,16 +28,16 @@
         <tag>fabric-sdk-java-1.0</tag>
     </scm>
     <properties>
-        <grpc.version>1.43.2</grpc.version>
-        <protobuf.version>3.19.2</protobuf.version> <!-- Must match version used by grpc-protobuf -->
+        <grpc.version>1.49.1</grpc.version>
+        <protobuf.version>3.21.1</protobuf.version> <!-- Must match version used by grpc-protobuf -->
         <bouncycastle.version>1.70</bouncycastle.version>
         <httpclient.version>4.5.13</httpclient.version>
         <javadoc.version>3.2.0</javadoc.version>
         <skipITs>true</skipITs>
         <alpn-boot-version>8.1.7.v20160121</alpn-boot-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jacoco.version>0.8.5</jacoco.version>
-        <log4j.version>2.17.1</log4j.version>
+        <jacoco.version>0.8.8</jacoco.version>
+        <log4j.version>2.19.0</log4j.version>
         <org.hyperledger.fabric.sdktest.ITSuite>IntegrationSuite.java</org.hyperledger.fabric.sdktest.ITSuite>
         <gpg.executable>gpg</gpg.executable>
     </properties>
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.2.0</version>
+            <version>4.8.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>2.0.47.Final</version>
+            <version>2.0.54.Final</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
@@ -201,7 +201,7 @@
         <dependency>
             <groupId>com.google.api</groupId>
             <artifactId>api-common</artifactId>
-            <version>2.1.2</version>
+            <version>2.2.1</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.glassfish/javax.json -->
@@ -647,7 +647,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>7.1.0</version>
+                        <version>7.2.1</version>
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipTestScope>true</skipTestScope>


### PR DESCRIPTION
netty-tcnative-boringssl-static caused linkage errors on M1 Mac when using a native arm64 JVM.