### PR TITLE
Change executor service defaults

### DIFF
--- a/src/main/java/org/hyperledger/fabric/sdk/HFClient.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/HFClient.java
@@ -28,9 +28,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -66,18 +64,15 @@ public class HFClient {
         }
     }
 
-    ExecutorService getExecutorService() {
+    public ExecutorService getExecutorService() {
         if (null == executorService) {
             synchronized (this) { //was null so lets get a lock for safe update.
                 if (null == executorService) { // no other thread has done it ...
-                    executorService = new ThreadPoolExecutor(CLIENT_THREAD_EXECUTOR_COREPOOLSIZE, CLIENT_THREAD_EXECUTOR_MAXIMUMPOOLSIZE,
-                            CLIENT_THREAD_EXECUTOR_KEEPALIVETIME, CLIENT_THREAD_EXECUTOR_KEEPALIVETIMEUNIT,
-                            new SynchronousQueue<>(),
-                            r -> {
-                                Thread t = threadFactory.newThread(r);
-                                t.setDaemon(true);
-                                return t;
-                            });
+                    executorService = Executors.newFixedThreadPool(CLIENT_THREAD_EXECUTOR_POOLSIZE, r -> {
+                        Thread t = threadFactory.newThread(r);
+                        t.setDaemon(true);
+                        return t;
+                    });
                 }
             }
 
@@ -97,10 +92,7 @@ public class HFClient {
 
     protected final ThreadFactory threadFactory = Executors.defaultThreadFactory();
 
-    private static final int CLIENT_THREAD_EXECUTOR_COREPOOLSIZE = config.getClientThreadExecutorCorePoolSize();
-    private static final int CLIENT_THREAD_EXECUTOR_MAXIMUMPOOLSIZE = config.getClientThreadExecutorMaxiumPoolSize();
-    private static final long CLIENT_THREAD_EXECUTOR_KEEPALIVETIME = config.getClientThreadExecutorKeepAliveTime();
-    private static final TimeUnit CLIENT_THREAD_EXECUTOR_KEEPALIVETIMEUNIT = config.getClientThreadExecutorKeepAliveTimeUnit();
+    private static final int CLIENT_THREAD_EXECUTOR_POOLSIZE = Math.max(config.getClientThreadExecutorCorePoolSize(), config.getClientThreadExecutorMaxiumPoolSize());
 
     private HFClient() {
     }

--- a/src/main/java/org/hyperledger/fabric/sdk/helper/Config.java
+++ b/src/main/java/org/hyperledger/fabric/sdk/helper/Config.java
@@ -25,9 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.OpenTelemetrySdkBuilder;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
-import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.Level;
@@ -182,9 +180,10 @@ public class Config {
              * Default HFClient thread executor settings.
              */
 
-            defaultProperty(CLIENT_THREAD_EXECUTOR_COREPOOLSIZE, "0");
-            defaultProperty(CLIENT_THREAD_EXECUTOR_MAXIMUMPOOLSIZE, "" + Integer.MAX_VALUE);
-            defaultProperty(CLIENT_THREAD_EXECUTOR_KEEPALIVETIME, "" + "60");
+            int availableProcessors = Runtime.getRuntime().availableProcessors();
+            defaultProperty(CLIENT_THREAD_EXECUTOR_COREPOOLSIZE, Integer.toString(availableProcessors + 1));
+            defaultProperty(CLIENT_THREAD_EXECUTOR_MAXIMUMPOOLSIZE, Integer.toString(availableProcessors + 1));
+            defaultProperty(CLIENT_THREAD_EXECUTOR_KEEPALIVETIME, "60");
             defaultProperty(CLIENT_THREAD_EXECUTOR_KEEPALIVETIMEUNIT, "SECONDS");
 
             /**


### PR DESCRIPTION
- Set the default core and maximum thread pool size to Runtime.getRuntime().availableProcessors() + 1.
- Use a fixed thread pool using the larger of core or maximum thread pool, and an unbounded queue to prevent failures submitting work when all threads are in use.
- Make HFClient.getExecutorService() public.

The default (effectively) unlimited thread pool size could cause so many threads to be created under high event load that system failures could occur.

Relates to hyperledger/fabric-gateway-java#124