### PR TITLE
Allow optional semrev 'v' prefix in fabric-ca reported version

### DIFF
--- a/src/test/java/org/hyperledger/fabric_ca/sdkintegration/HFCAClientIT.java
+++ b/src/test/java/org/hyperledger/fabric_ca/sdkintegration/HFCAClientIT.java
@@ -1106,7 +1106,7 @@ public class HFCAClientIT {
             assertNotNull("client.info returned null.", info);
             String version = info.getVersion();
             assertNotNull("client.info.getVersion returned null.", version);
-            assertTrue(format("Version '%s' didn't match expected pattern", version), version.matches("^\\d+\\.\\d+\\.\\d+($|-.*)"));
+            assertTrue(format("Version '%s' didn't match expected pattern", version), version.matches("^v?\\d+\\.\\d+\\.\\d+($|-.*)"));
         }
 
     }


### PR DESCRIPTION
Allows the version reported by fabric CA to include an optional leading semrev 'v' character.

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>