### PR TITLE
Refactor CI pipeline (release-2.2)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,14 @@
+name: Pull request
+
+on:
+  pull_request:
+    branches:
+      - release-2.2
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/test.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,10 @@
+name: Push
+
+on:
+  push:
+    branches:
+      - release-2.2
+
+jobs:
+  build:
+    uses: ./.github/workflows/test.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,19 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - release-2.2
-  pull_request:
-    branches:
-      - release-2.2
+  workflow_call:
+    inputs:
+      fabric-version:
+        default: '2.2'
+        required: false
+        type: string
+      checkout-ref:
+        default: ''
+        required: false
+        type: string
 
 env:
-  FABRIC_VERSION: "2.2"
+  FABRIC_VERSION: ${{ inputs.fabric-version }}
   GOPATH: ${{ github.workspace }}/src/test/fixture
 
 jobs:
@@ -24,6 +28,8 @@ jobs:
           - "17"
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.checkout-ref }}
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:

--- a/scripts/pull-fabric-images.sh
+++ b/scripts/pull-fabric-images.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 set -euo pipefail
 
-# FABRIC_VERSION is set in .github/workflows/build.yml
+# FABRIC_VERSION is set overridden by CI pipeline
 VERSION=${FABRIC_VERSION:-2.2}
 STABLE_TAG=amd64-${VERSION}-stable
 


### PR DESCRIPTION
- Split tests to callable workflow to enable multi-release scheduled builds
- Automatic cancel of in-progress pull request builds on a new push