### PR TITLE
Use repository variable to refer to workflows in scheduled build

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -3,12 +3,15 @@ name: Scheduled build
 on:
   schedule:
     - cron: "5 0 * * *"
+  pull_request:
+    branches:
+      - main
 
 jobs:
   main:
     uses: ./.github/workflows/test.yml
   release-2_2:
     name: release-2.2
-    uses: hyperledger/fabric-sdk-java/.github/workflows/test.yml@release-2.2
+    uses: ${{ github.repository }}/.github/workflows/test.yml@release-2.2
     with:
       checkout-ref: release-2.2


### PR DESCRIPTION
Avoid hard-coding repository organization / name into workflow.