### PR TITLE
Pull Fabric images from DockerHub

### DIFF
--- a/scripts/pull-fabric-images.sh
+++ b/scripts/pull-fabric-images.sh
@@ -2,15 +2,13 @@
 set -euo pipefail
 
 # FABRIC_VERSION is overridden by CI pipeline
-VERSION=${FABRIC_VERSION:-2.2}
-STABLE_TAG=amd64-${VERSION}-stable
+FABRIC_VERSION=${FABRIC_VERSION:-2.2}
+CA_VERSION=${CA_VERSION:-1.4}
 
 for image in peer orderer tools ccenv baseos javaenv nodeenv; do
-	docker pull -q hyperledger-fabric.jfrog.io/fabric-${image}:${STABLE_TAG}
-	docker tag hyperledger-fabric.jfrog.io/fabric-${image}:${STABLE_TAG} hyperledger/fabric-${image}
-	docker rmi -f hyperledger-fabric.jfrog.io/fabric-${image}:${STABLE_TAG} >/dev/null
+	docker pull -q "hyperledger/fabric-${image}:${FABRIC_VERSION}"
+	docker tag "hyperledger/fabric-${image}:${FABRIC_VERSION}" "hyperledger/fabric-${image}"
 done
 
-docker pull -q hyperledger/fabric-ca:1.4
-docker tag hyperledger/fabric-ca:1.4 hyperledger/fabric-ca
-docker rmi -f hyperledger/fabric-ca:1.4 >/dev/null
+docker pull -q "hyperledger/fabric-ca:${CA_VERSION}"
+docker tag "hyperledger/fabric-ca:${CA_VERSION}" hyperledger/fabric-ca


### PR DESCRIPTION
Avoid using artifactory as this may go away in the future. This API is not actively developed so development images of Fabric are not required and release images are sufficient.