### PR TITLE
ignoring unnecessarily generated surefire report

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -30,7 +30,7 @@ docker ps -a
 
 export ORG_HYPERLEDGER_FABRIC_SDK_DIAGNOSTICFILEDIR=target/diagDump
 export MAVEN_OPTS="-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
-mvn -B clean install -DskipITs=false -Dmaven.test.failure.ignore=false javadoc:javadoc
+mvn -B clean install -DskipITs=false -Dmaven.test.failure.ignore=false javadoc:javadoc -DdisableXmlReport=true
 
 pushd src/test/fixture/sdkintegration/ >/dev/null
 docker-compose down --volumes


### PR DESCRIPTION
In our analysis, we observe that this target/surefire-report/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime.
The generation of this directory can be disabled by simply adding -DdisableXmlReport=true to the mvn command.