### PR TITLE
Remove netty-tcnative-boringssl-static dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,9 @@
         <url>http://github.com/hyperledger/fabric-sdk-java</url>
     </scm>
     <properties>
-        <grpc.version>1.53.0</grpc.version>
-        <protobuf.version>3.21.7</protobuf.version> <!-- Must match version used by grpc-protobuf -->
-        <bouncycastle.version>1.70</bouncycastle.version>
+        <grpc.version>1.54.1</grpc.version>
+        <protobuf.version>3.21.12</protobuf.version> <!-- Must match version used by grpc-protobuf -->
+        <bouncycastle.version>1.73</bouncycastle.version>
         <httpclient.version>4.5.14</httpclient.version>
         <javadoc.version>3.2.0</javadoc.version>
         <skipITs>true</skipITs>
@@ -109,11 +109,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>2.0.58.Final</version>
-        </dependency>
-        <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
         </dependency>
@@ -138,10 +133,14 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>${bouncycastle.version}</version>
+        </dependency>
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>


### PR DESCRIPTION
Not required since tcnative with BoringSSL is already included in grpc-netty-shaded dependency.
    
Also update Bouncy Castle dependency to implementations for Java 1.8 and later only.