### PR TITLE
Use v2.2.x Java and Node chaincode APIs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,4 +18,4 @@ jobs:
     name: Pull request success
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - run: 'true'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,8 +17,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: temurin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: temurin
@@ -31,8 +31,8 @@ jobs:
     name: Publish Java artifact to Maven Central
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: temurin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,11 @@ jobs:
           - "11"
           - "17"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.checkout-ref }}
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
           distribution: temurin

--- a/src/test/fixture/sdkintegration/javacc/1.4/sample1/build.gradle
+++ b/src/test/fixture/sdkintegration/javacc/1.4/sample1/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '1.+'
+    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '1.4.+'
 }
 
 shadowJar {

--- a/src/test/fixture/sdkintegration/javacc/2.1/sample1/build.gradle
+++ b/src/test/fixture/sdkintegration/javacc/2.1/sample1/build.gradle
@@ -16,8 +16,8 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.+'
-    implementation 'commons-logging:commons-logging:1.2'
+    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.2.+'
+    implementation 'commons-logging:commons-logging:1.3.0'
 }
 
 shadowJar {

--- a/src/test/fixture/sdkintegration/nodecc/sample1/package.json
+++ b/src/test/fixture/sdkintegration/nodecc/sample1/package.json
@@ -13,6 +13,6 @@
     },
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-shim": "2.1.0"
+        "fabric-shim": "^2.2.0"
     }
 }

--- a/src/test/fixture/sdkintegration/nodecc/sample_11/package.json
+++ b/src/test/fixture/sdkintegration/nodecc/sample_11/package.json
@@ -13,6 +13,6 @@
     },
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-shim": "2.1.0"
+        "fabric-shim": "^2.2.0"
     }
 }


### PR DESCRIPTION
Lax version constraints introduced incompatibilities with Fabric v2.2 with recent v2.5 API versions.

Also update some GitHub Actions versions.